### PR TITLE
Exclude .cache directory in Jekyll config

### DIFF
--- a/_config.global.yml
+++ b/_config.global.yml
@@ -32,6 +32,7 @@ exclude:
     - _studies/*.jpg        # Study images
     - _studies/*.png        # Study images
     - _studies/*.pdf        # Original study infographics (build moves them to assets)
+    - .cache/               # Intermediate files
 
 sass:
     sass_dir: assets/_scss


### PR DESCRIPTION
Jekyll apparently uses the exclude list when watching for changes in files (e.g. when running `jekyll serve`). Since files in the `.cache` directory may change after each build, Jekyll is prone to fall into an endless loop of rebuilding the site over and over again. See, for instance, jekyll/jekyll#736.