### PR TITLE
Use explainer cover image as OG preview

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -29,6 +29,8 @@
   {% assign social_image = "/assets/generated/" | append: page.slug | append: "_1200.png" %}
 {% when 'study' %}
   {% assign social_image = "/assets/studies/" | append: page.slug | append: ".jpg" %}
+{% when 'explainer' %}
+  {% assign social_image = "/assets-local/cover/" | append: page.slug | append: ".jpg" %}
 {% else %}
   {% assign social_image = "/assets-local/img/preview.png" %}
 {% endcase %}


### PR DESCRIPTION
Allow for social media links to explainers to display the cover image as a preview for the page via Open Graph tags.