### PR TITLE
Allow explainers in preview box

### DIFF
--- a/_includes/preview-block.html
+++ b/_includes/preview-block.html
@@ -18,7 +18,8 @@
         </div>
         {%- endunless %}
     {% when 'explainer' %}
-        <img src="/assets-local/cover/{{ item.slug }}.jpg" alt="Explainer: {{ item.title }}" title="Explainer: {{ item.title }}" class="img-fluid card-img" />
+        <div style="background-image: url('/assets-local/cover/{{ item.slug }}.jpg')" title="Explainer: {{ item.title }}" class="preview-card-image img-fluid card-img">
+        </div>
         <div class="card-img-overlay card-dataset-overlay">
         <h5 class="card-title">{{ item.title }}</h5>
         <h6 class="card-subtitle">Explainer</h6>

--- a/_includes/preview-box.html
+++ b/_includes/preview-box.html
@@ -11,7 +11,7 @@
 {%- if include.slug %}
 <div class="row">
   {% for needle in slugs %}
-    <div class="{{ include.card_class | default: 'py-1' }}">
+    <div class="{{ include.card_class | default: 'py-1 w-100' }}">
       {% assign item = site.infographics | concat: site.studies | concat: site.explainers | find_exp:"item","item.slug == needle" %}
       <a href="{{ item.url }}" class="preview-card card">
         {% include preview-block.html item=item no_include_tags=true %}

--- a/_includes/preview-box.html
+++ b/_includes/preview-box.html
@@ -12,7 +12,7 @@
 <div class="row">
   {% for needle in slugs %}
     <div class="{{ include.card_class | default: 'py-1' }}">
-      {% assign item = site.infographics | concat: site.studies | find_exp:"item","item.slug == needle" %}
+      {% assign item = site.infographics | concat: site.studies | concat: site.explainers | find_exp:"item","item.slug == needle" %}
       <a href="{{ item.url }}" class="preview-card card">
         {% include preview-block.html item=item no_include_tags=true %}
       </a>

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -66,6 +66,12 @@
     }
 }
 
+.preview-card-image {
+    // Add 70% of the 4px border as well.
+    padding-bottom: calc(70% + 3px);
+    background-size: cover;
+}
+
 a.card:hover {
     border-color: rgba($c-primary, 0.5);
     text-decoration: none;


### PR DESCRIPTION
Allow for explainers to be referenced in preview boxes (via`preview-box.html`).

Related: faktaoklimatu/web-cz#781