### PR TITLE
Generate resized version of explainer covers (for preview boxes and more)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Generated web files
 assets/generated/*
 assets/studies/*
+assets/covers/*
 _config.yml
 humans.txt
 robots.txt

--- a/.travis.global.yml
+++ b/.travis.global.yml
@@ -14,6 +14,7 @@ addons:
       - sourceline: 'ppa:inkscape.dev/stable'
     packages:
     - inkscape
+    - imagemagick
 
 # Restore file times for better GNU Make optimizations
 before_install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install --assume-yes software-properties-common
 RUN add-apt-repository --yes ppa:inkscape.dev/stable && apt update
 RUN apt install --assume-yes --no-install-suggests --no-install-recommends \
-        build-essential git inkscape ruby-bundler ruby-dev zlib1g-dev libffi-dev
+        build-essential git inkscape ruby-bundler ruby-dev zlib1g-dev libffi-dev imagemagick
 
 EXPOSE 4000
 VOLUME /srv/jekyll

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ DATASETS_DST=$(addprefix $(DATASETS_FOLDER)/,$(notdir $(DATASETS_SRC:.md=.png)))
 STUDIES_FOLDER=assets/studies
 STUDIES_SRC=$(wildcard _studies/*.jpg _studies/*.png)
 STUDIES_DST=$(addprefix $(STUDIES_FOLDER)/,$(notdir $(STUDIES_SRC)))
+COVERS_FOLDER=assets/covers
+COVERS_SRC=$(wildcard _explainers/*.jpg)
+COVERS_DST=$(addprefix $(COVERS_FOLDER)/,$(notdir $(COVERS_SRC)))
 
 PODMAN=podman
 CONTAINER_IMAGE=factsonclimate/web
@@ -47,10 +50,10 @@ humans.txt: ../CONTRIBUTORS.md
 robots.txt: .well-known-templates/robots.txt _config.yml
 	sed "s|{{ URL }}|$(URL)|" $< >$@
 
-local: $(INFOGRAPHICS_DST) $(STUDIES_DST) bundle-install _config.yml humans.txt robots.txt .well-known/security.txt
+local: $(INFOGRAPHICS_DST) $(STUDIES_DST) $(COVERS_DST) bundle-install _config.yml humans.txt robots.txt .well-known/security.txt
 	bundle exec jekyll serve --trace
 
-build: $(INFOGRAPHICS_DST) $(STUDIES_DST) bundle-install _config.yml humans.txt robots.txt .well-known/security.txt
+build: $(INFOGRAPHICS_DST) $(STUDIES_DST) $(COVERS_DST) bundle-install _config.yml humans.txt robots.txt .well-known/security.txt
 	@echo "Building the website using Jekyll ..."
 	@if [ "$(TRAVIS_BRANCH)" = "master" ]; then echo "=== Production build ==="; else echo "=== Development build ==="; fi
 	if [ "$(TRAVIS_BRANCH)" = "master" ]; then JEKYLL_ENV=production bundle exec jekyll build; else bundle exec jekyll build; fi
@@ -64,6 +67,7 @@ check: build
 clean:
 	rm -rf $(INFOGRAPHICS_FOLDER)
 	rm -rf $(STUDIES_FOLDER)
+	rm -rf $(COVERS_FOLDER)
 	rm -f robots.txt .well-known/security.txt humans.txt _config.yml
 
 $(INFOGRAPHICS_FOLDER)/%.pdf: _infographics/*/%.pdf
@@ -75,6 +79,9 @@ $(INFOGRAPHICS_FOLDER)/%.pdf: _studies/%.pdf
 $(STUDIES_FOLDER)/%: _studies/%
 	mkdir -p $(@D)
 	cp $< $@
+
+$(COVERS_FOLDER)/%: _explainers/%
+	@utils/convert-cover.sh $< $@
 
 dataset-images: $(DATASETS_DST)
 

--- a/_config.global.yml
+++ b/_config.global.yml
@@ -31,6 +31,7 @@ exclude:
     - _studies/*.jpg        # Study images
     - _studies/*.png        # Study images
     - _studies/*.pdf        # Original study infographics (build moves them to assets)
+    - _explainers/*.jpg     # Explainer cover image
     - .cache/               # Intermediate files
 
 sass:

--- a/_includes/preview-block.html
+++ b/_includes/preview-block.html
@@ -18,7 +18,7 @@
         </div>
         {%- endunless %}
     {% when 'explainer' %}
-        <div style="background-image: url('/assets-local/cover/{{ item.slug }}.jpg')" title="{{ site.data.lang.text.explainer.explainer }}: {{ item.title }}" class="preview-card-image img-fluid card-img">
+        <div style="background-image: url('/assets/covers/{{ item.slug }}_600.jpg')" title="{{ site.data.lang.text.explainer.explainer }}: {{ item.title }}" class="preview-card-image img-fluid card-img">
         </div>
         <div class="card-img-overlay card-dataset-overlay">
         <h5 class="card-title">{{ item.title }}</h5>

--- a/_layouts/explainer.html
+++ b/_layouts/explainer.html
@@ -31,7 +31,9 @@
     </div>
     {%- endif %}
     <div class="explainer-cover-container">
-      <div class="explainer-cover section" style="--path: url(/assets-local/cover/{{ page.slug }}.jpg);">
+      <div class="explainer-cover section"
+          style="--path-desktop: url(/assets/covers/{{ page.slug }}.jpg);
+                 --path-mobile: url(/assets/covers/{{ page.slug }}_1150.jpg)">
         <div class="container clearfix">
           <div class="row justify-content-center">
             <div class="col">

--- a/_plugins/glyph-replacement.rb
+++ b/_plugins/glyph-replacement.rb
@@ -4,6 +4,7 @@ Jekyll::Hooks.register :site, :post_render do |site|
   Jekyll.logger.info  "                  * Replacing special spaces ..."
   
   site.documents.each do |page|
+    Jekyll.logger.error "Undefined page.output for '#{page.path}'. Consider excluding this file" if not page.respond_to? :output
     replace!(page.output)
   end
 end

--- a/assets/_scss/explainer.scss
+++ b/assets/_scss/explainer.scss
@@ -6,7 +6,7 @@
 .explainer-cover::before {
     content: " ";
     display: block;
-    background-image: var(--path);
+    background-image: var(--path-mobile);
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
@@ -108,7 +108,7 @@
     }
 
     .explainer-cover {
-        background-image: var(--path);
+        background-image: var(--path-desktop);
         background-position: center;
         background-repeat: no-repeat;
         background-size: cover;

--- a/utils/convert-cover.sh
+++ b/utils/convert-cover.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Validate command line arguments
+if [ ! $# -eq 2 ]
+then
+    echo "Error: Incorrect number of parameters (exactly 2 parameters required)."
+    echo "Usage: "$0" <source/infographic.pdf> <destination/infographic.pdf>"
+    exit 1
+fi
+
+# ImageMagick install instructions
+image_magick_install_instructions() {
+    echo "On Ubuntu, install ImageMagick using the commands below."
+    echo "  sudo apt update"
+    echo "  sudo apt install imagemagick"
+}
+
+# Check for convert availability
+if ! (which convert >/dev/null 2>&1)
+then
+    echo "Error: ImageMagick not installed."
+    image_magick_install_instructions
+    exit 2
+fi
+
+# Exit when any command fails
+set -e
+
+# Widths (in px) of covers we want to generate in PNG
+WIDTHS=(600 1150)
+
+# Set up file names
+SRC_FILE_JPG=$1
+DST_FILE_JPG=$2
+
+# Create destination folder if necessary
+mkdir -p $(dirname $DST_FILE_PDF)
+
+resize_jpg() {
+    input_jpg=$1
+    width=$2
+    convert \
+        "$input_jpg" \
+        -resize ${width}x
+        "${input_jpg%.jpg}_$width.jpg" \
+        >/dev/null 2>&1
+}
+
+# Resize cover into JPGs of various sizes.
+for width in ${WIDTHS[@]}; do
+    echo -e `basename $DST_FILE_JPG`": converting to PNG (${width}px)..."
+    resize_jpg "$SRC_FILE_JPG" $width
+done
+
+# If all previous conversions pass, copy the main cover, checked by Make.
+echo `basename $SRC_FILE_JPG`": copying to $DST_FILE_JPG..."
+cp "$SRC_FILE_JPG" "$DST_FILE_JPG"
+
+echo `basename $SRC_FILE_JPG`": All done."

--- a/utils/convert-cover.sh
+++ b/utils/convert-cover.sh
@@ -34,26 +34,25 @@ SRC_FILE_JPG=$1
 DST_FILE_JPG=$2
 
 # Create destination folder if necessary
-mkdir -p $(dirname $DST_FILE_PDF)
+mkdir -p $(dirname $DST_FILE_JPG)
 
 resize_jpg() {
     input_jpg=$1
     width=$2
     convert \
         "$input_jpg" \
-        -resize ${width}x
+        -resize "${width}x" \
         "${input_jpg%.jpg}_$width.jpg" \
         >/dev/null 2>&1
 }
 
-# Resize cover into JPGs of various sizes.
-for width in ${WIDTHS[@]}; do
-    echo -e `basename $DST_FILE_JPG`": converting to PNG (${width}px)..."
-    resize_jpg "$SRC_FILE_JPG" $width
-done
-
-# If all previous conversions pass, copy the main cover, checked by Make.
 echo `basename $SRC_FILE_JPG`": copying to $DST_FILE_JPG..."
 cp "$SRC_FILE_JPG" "$DST_FILE_JPG"
+
+# Resize cover into JPGs of various sizes.
+for width in ${WIDTHS[@]}; do
+    echo -e `basename $DST_FILE_JPG`": resizing to JPG (${width}px)..."
+    resize_jpg "$DST_FILE_JPG" $width
+done
 
 echo `basename $SRC_FILE_JPG`": All done."


### PR DESCRIPTION
This PR sets up Makefile to generate resized version of cover images. For consistency, these cover images are now assumed to be next to its .md file. The resized versions are used for the preview box and for the actual page on mobile.

Fixes #36.