### PR TITLE
Further search fixes

### DIFF
--- a/_includes/preview-block-small.html
+++ b/_includes/preview-block-small.html
@@ -1,29 +1,40 @@
-{% assign item = include.item %}
-{% case item.layout %}
-    {% when 'infographic' %}
+{%- assign item = include.item %}
+{%- case item.layout %}
+    {%- when 'infographic' %}
         <img src="/assets/generated/{{ item.slug }}_600.png" alt="{{ item.title }}" class="img-fluid" />
-    {% when 'dataset' %}
+    {%- when 'dataset' %}
         <img src="/assets/datasets/{{ item.slug }}.png" alt="{{ site.data.lang.text.dataset.dataset }}: {{ item.title }}" class="img-fluid card-img" />
         <div class="card-img-overlay small-card-img-overlay">
             <h5>{{ site.data.lang.text.dataset.dataset }}</h5>
         </div>
-    {% when 'explainer' %}
+    {%- when 'explainer' %}
         <img src="/assets/covers/{{ item.slug }}_600.jpg" alt="{{ site.data.lang.text.explainer.explainer }}: {{ item.title }}" class="img-fluid card-img" />
         <div class="card-img-overlay small-card-img-overlay">
             <h5>{{ site.data.lang.text.explainer.explainer }}</h5>
         </div>
-    {% when 'study' %}
+    {%- when 'study' %}
         <img src="/assets/studies/{{ item.slug }}.jpg" alt="{{ site.data.lang.text.study.study }}: {{ item.title }}" class="img-fluid card-img" />
         <div class="card-img-overlay small-card-img-overlay">
             <h5>{{ site.data.lang.text.study.study }}</h5>
         </div>
-    {% when 'survey' %}
+    {%- when 'survey' %}
         <div class='branded-card'></div>
         <div class="card-img-overlay small-card-img-overlay">
             <h5>{{ site.data.lang.text.survey.survey }}</h5>
         </div>
-    {% else %}
-        <div class="card-img-overlay small-card-img-overlay">
-            <h5>Unknown type</h5>
-        </div>
-{% endcase %}
+    {%- else %}
+        {%- if item.search_type %}
+            {%- if item.search_image %}
+                <img src="{{ item.search_image }}" alt="{{ page.search_type }}: {{ item.title }}" class="img-fluid card-img" />
+            {%- else %}
+                <div class='branded-card'></div>
+            {%- endif %}
+            <div class='card-img-overlay small-card-img-overlay'>
+                <h5>{{ page.search_type }}</h5>
+            </div>
+        {%- else %}
+            <div class="card-img-overlay small-card-img-overlay">
+                <h5>Unknown type</h5>
+            </div>
+        {%- endif %}
+{%- endcase %}

--- a/assets/_scss/search.scss
+++ b/assets/_scss/search.scss
@@ -54,6 +54,10 @@ nav.navbar-search {
         margin-top: 0;
         box-shadow: 0 0 0.5rem rgba(0,0,0,0.4);
     }
+
+    #searchHide:not(:hover) {
+        background-color: white;
+    }
 }
 
 /* Search results */

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -77,6 +77,11 @@ class Search {
         $(this.selectors.searchbox).on('keyup', $.proxy(this.delayedSearch, this));
 
         $(this.selectors.results).on('blur', $.proxy(this.maybeHideSearch, this));
+
+        // With open suggestions we set a fixed body width which does not work with resizing content. Hide suggestions on
+        // resize to avoid this glitch. Clicking the input box will reshow the suggestions.
+        $(window).on('resize', $.proxy(this.hideSuggestions, this));
+        $(this.selectors.searchbox).on('click', $.proxy(this.instantSearch, this));
     }
 
     /**

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -78,10 +78,9 @@ class Search {
 
         $(this.selectors.results).on('blur', $.proxy(this.maybeHideSearch, this));
 
-        // With open suggestions we set a fixed body width which does not work with resizing content. Hide suggestions on
-        // resize to avoid this glitch. Clicking the input box will reshow the suggestions.
-        $(window).on('resize', $.proxy(this.hideSuggestions, this));
-        $(this.selectors.searchbox).on('click', $.proxy(this.instantSearch, this));
+        // With open suggestions we set a fixed body width which does not work with resizing content. Hide search on resize
+        // to avoid this glitch.
+        $(window).on('resize', $.proxy(this.hideSearch, this));
     }
 
     /**

--- a/search.json
+++ b/search.json
@@ -2,56 +2,16 @@
 layout: null
 ---
 [
-  {%- assign page = site.pages | find:"search_id","glossary" %}
-  {%- if page %}
-    {
-      "title" : "{{ page.title }}",
-      "url" : "{{ page.url }}",
-      "block" : "<div class='branded-card'></div><div class='card-img-overlay small-card-img-overlay'><h5>{{ page.search_type }}</h5></div>",
-      {%- capture content %}
-      {%- for item in site.data.glossary %} {{ item.name-short }} {{ item.name-long }} {{ item.description }}{% endfor %}
-      {%- endcapture %}
-      "content" : "{{ content | markdownify | normalize_whitespace | strip | strip_html | strip_newlines | replace: '"', '' }}"
-    },
-  {%- endif %}
-
-  {%- assign page = site.pages | find:"search_id","resources" %}
-  {%- if page %}
-    {
-      "title" : "{{ page.title }}",
-      "url" : "{{ page.url }}",
-      "block" : "<div class='branded-card'></div><div class='card-img-overlay small-card-img-overlay'><h5>{{ page.search_type }}</h5></div>",
-      {%- capture content %}
-        {%- for res in site.data.resources %}
-          {%- for item in res[1].items %} {{ item.title }} {{ item.name-long }} {{ item.description-short }} {{ item.description-long }}{% endfor %}
-        {%- endfor %}
-      {%- endcapture %}
-      "content" : "{{ content | markdownify | normalize_whitespace | strip | strip_html | strip_newlines | replace: '"', '' }}"
-    },
-  {%- endif %}
-
-  {%- assign page = site.pages | find:"search_id","news" %}
-  {%- if page %}
-    {
-      "title" : "{{ page.title }}",
-      "url" : "{{ page.url }}",
-      "block" : "<div class='branded-card'></div><div class='card-img-overlay small-card-img-overlay'><h5>{{ page.search_type }}</h5></div>",
-      {%- capture content %}
-        {%- for item in site.data.news %} {{ item.title }} {{ item.summary }}{%- endfor %}
-      {%- endcapture %}
-      "content" : "{{ content | markdownify | normalize_whitespace | strip | strip_html | strip_newlines | replace: '"', '' }}"
-    },
-  {%- endif %}
-
+  {%- assign pages = site.pages | where_exp: "page", "page.search_type" %}
   {%- assign objects = site.infographics | concat: site.studies | concat: site.explainers | sort: "published" | reverse %}
-  {%- for page in objects %}
+  {%- assign all = pages | concat: objects %}
+  {%- for page in all %}
     {
         "title" : "{{ page.title | strip_html }}",
         "url" : "{{ page.url }}",
-        "slug" : "{{ page.slug }}",
         {%- capture html %}{% include preview-block-small.html item=page %}{%- endcapture %}
-        "block" : {{ html | jsonify }},
-        {%- assign perex = page.caption | append: " " | append: page.perex %}
+        "block" : {{ html | normalize_whitespace | jsonify }},
+        {%- assign perex = page.caption | append: " " | append: page.perex | append: " " | append: page.intro %}
         "perex" : "{{ perex | normalize_whitespace | strip | strip_html | strip_newlines | replace: '"', '' }}",
         "content" : "{{ page.content | markdownify | normalize_whitespace | strip | strip_html | strip_newlines | replace: '"', '' | slice: 0, 3000 }}"
     }{%- if forloop.last %}{% else %},{% endif %}


### PR DESCRIPTION
This CL makes several small improvements:
 - the [X] button is now fully opaque,
 - resizing window when search results are open hides the results (so that resizing works well),
 - search.json got simplified (and now supports arbitrary many special pages, even with custom images).