### PR TITLE
Add option to have captions in figures

### DIFF
--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -1,8 +1,13 @@
 <div class="longread-figure">
   <img src="/assets-local/figures/{{ page.slug }}/{{ include.name }}" alt="{{ include.alt }}">
-  {%- if include.source-text and include.source-url %}
+  {%- if include.caption or (include.source-text and include.source-url) %}
   <div class="source">
-    Zdroj: <a href="{{ include.source-url }}">{{ include.source-text }}</a>
+    {%- if include.caption %}
+      {{- include.caption }} 
+    {%- endif %}
+    {%- if include.source-text %}
+      Zdroj: <a href="{{ include.source-url }}">{{ include.source-text }}</a>
+    {%- endif %}
   </div>
   {%- endif %}
 </div>

--- a/assets/_scss/infographic.scss
+++ b/assets/_scss/infographic.scss
@@ -189,8 +189,9 @@ div.longread-figure {
     }
     .source {
         text-align: right;
-        margin-right: 1rem;
+        margin: 0.5rem 0.5rem 0 0.5rem;
         font-size: 0.8rem;
+        line-height: 150%;
         color: $c-grey;
         a {
             color: $c-grey;


### PR DESCRIPTION
Currently not ideal (the text is probably too small) but the interaction with mentioning the source is not trivial.
Though, I think that this solution is sufficient for now. If so, I'll create an issue on the matter.

For preview, see corals explainer at https://cz-fakta-o-klimatu--preview-explainer-korali-eor1y6go.web.app