### PR TITLE
Add support for math formulae

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,14 @@
 source 'https://rubygems.org'
 
+gem 'duktape'
+gem 'execjs'
 gem 'ffi-icu'
 gem 'html-proofer'
 gem 'jekyll'
 gem 'jekyll-last-modified-at'
 gem 'jekyll-redirect-from'
 gem 'jekyll-sitemap'
+gem 'kramdown-math-katex'
 gem 'nokogumbo'
 
 # The plugin in the gem repository is ccurrently not maintained.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,12 +5,14 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.8)
+    duktape (2.6.0.0)
     em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
+    execjs (2.7.0)
     ffi (1.15.0)
     ffi-icu (0.3.0)
       ffi (~> 1.0, >= 1.0.9)
@@ -52,8 +54,13 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    katex (0.6.1)
+      execjs (~> 2.7)
     kramdown (2.3.1)
       rexml
+    kramdown-math-katex (1.0.1)
+      katex (~> 0.4)
+      kramdown (~> 2.0)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
@@ -96,12 +103,15 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  duktape
+  execjs
   ffi-icu
   html-proofer
   jekyll
   jekyll-last-modified-at
   jekyll-redirect-from
   jekyll-sitemap
+  kramdown-math-katex
   nokogumbo
 
 BUNDLED WITH

--- a/_config.global.yml
+++ b/_config.global.yml
@@ -9,6 +9,8 @@ cdn:
     fa_hash:            "sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w=="
     jquery:             "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
     jquery_hash:        "sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ=="
+    katex_css:          "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.css"
+    katex_css_hash:     "sha512-SBL9R0mkYbWGuy/0DLHNxYHPScUMar9Y55t8vrnN42ZYfLZ4SnjXqCFfEhPTnj9pedAs5F+WZkzjq1qGS8+VGg=="
     bootstrap_js:       "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/js/bootstrap.bundle.min.js"
     bootstrap_js_hash:  "sha512-wV7Yj1alIZDqZFCUQJy85VN+qvEIly93fIQAN7iqDFCPEucLCeNFz4r35FCo9s6WrpdDQPi80xbljXB8Bjtvcg=="
     tocbot:             "https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.12.2/tocbot.min.js"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -53,6 +53,7 @@
 <link href="/assets/css/main.css?{{ site.time | date: '%s' }}" rel="stylesheet">
 <link href="/assets/fonts/source-sans-pro.css" rel="stylesheet">
 <link href="{{ site.cdn.fa }}" rel="stylesheet" integrity="{{ site.cdn.fa_hash }}" crossorigin="anonymous">
+<link href="{{ site.cdn.katex_css }}" rel="stylesheet" integrity="{{ site.cdn.katex_css_hash }}" crossorigin="anonymous">
 
 <link rel="icon" type="image/png" href="/assets/favicon.png">
 <link rel="canonical" href="{{ page.url | absolute_url }}" />


### PR DESCRIPTION
Render math formulae written in TeX syntax into MathML and HTML+CSS during compile time. This is done using [katex-ruby](https://github.com/glebm/katex-ruby) via the [kramdown-math-katex plugin](https://github.com/kramdown/math-katex).

Known issues:
- katex-ruby uses an older version of KaTeX (0.11.0 [August 2019] vs. 0.13.2 [April 2021]) – no substantial differences, though.
- Problems with double-escaping ampersands. Not an issues for the basic use case.