### PR TITLE
Fix search in Safari

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -52,7 +52,7 @@
             </button>
         </form>
         <div id="omnisearch-suggestions-container">
-            <div class="dropdown-menu" id="omnisearch-suggestions" aria-labelledby="searchbox">
+            <div class="dropdown-menu" id="omnisearch-suggestions" aria-labelledby="searchbox" tabindex="0">
             </div>
         </div>
     </div>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -47,12 +47,12 @@
     <div id="search-container" class="container">
         <form id="searchbox-form">
             <input class="form-control me-2" id="searchbox" data-bs-toggle="dropdown" type="search" placeholder="Hledat" aria-label="Hledat" autocomplete="off">
-            <button id="searchHide" class="btn btn-sm btn-outline-secondary" type="button" aria-label="Zrušit">
+            <button id="searchHide" class="btn btn-sm btn-outline-secondary" type="button" aria-label="Zrušit" tabindex="-1">
                 <i class="fas fa-fw fa-times"></i>
             </button>
         </form>
         <div id="omnisearch-suggestions-container">
-            <div class="dropdown-menu" id="omnisearch-suggestions" aria-labelledby="searchbox" tabindex="0">
+            <div class="dropdown-menu" id="omnisearch-suggestions" aria-labelledby="searchbox">
             </div>
         </div>
     </div>

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -241,7 +241,7 @@ class Search {
                        `<div class="search-preview card">${item.block}</div>` +
                        `<div class="snippet">${snippet}</div>`;
             let url = `${item.url}?q=${encodeURIComponent(this.searchString)}`;
-            resultsHtml += `<a class="dropdown-item clearfix" href="${url}">${card}</a>`;
+            resultsHtml += `<a class="dropdown-item clearfix" href="${url}" tabindex="0">${card}</a>`;
         });
         return resultsHtml;
     }

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -78,8 +78,8 @@ class Search {
 
         $(this.selectors.results).on('blur', $.proxy(this.maybeHideSearch, this));
 
-        // With open suggestions we set a fixed body width which does not work with resizing content. Hide search on resize
-        // to avoid this glitch.
+        // With open suggestions we set a fixed body width which does not work with
+        // resizing content. Hide search on resize to avoid this glitch.
         $(window).on('resize', $.proxy(this.hideSearch, this));
     }
 
@@ -97,8 +97,13 @@ class Search {
     }
 
     maybeHideSearch(event) {
+        // Do not hide if
+        // a) focus is lost to either the search box or the results list, or
+        // b) the whole window loses focus (e.g. when switching keyboard layout).
         if ($(this.selectors.searchbox)[0].contains(event.relatedTarget) ||
-            $(this.selectors.results)[0].contains(event.relatedTarget)) {
+            $(this.selectors.results)[0].contains(event.relatedTarget) ||
+            document.activeElement === event.target)
+        {
             return;
         }
         this.hideSearch();


### PR DESCRIPTION
In Safari, the onblur handler for the search input field failed to identify that the element gaining focus is the search result list. Thus, the handler closed the search result list before the click event got processed and the navigation to the search target did not proceed.

This PR adds tabindex=0 to the search results list so that this element gets populated to event.relatedTarget. This fixes the check that the element gains focus.

Fixes #59 