### PR TITLE
Correct Ruby keyword for skipping an iteration

### DIFF
--- a/_plugins/space-replacement.rb
+++ b/_plugins/space-replacement.rb
@@ -14,7 +14,7 @@ Jekyll::Hooks.register :site, :post_render do |site|
   site.documents.each do |page|
     if not page.respond_to? :output
       Jekyll.logger.error "Undefined page.output for '#{page.path}'. Consider excluding this file"
-      continue
+      next
     end
     replace!(page.output)
   end


### PR DESCRIPTION
It is `next` not `continue`.

Fixes #69