### PR TITLE
Adding jekyll-tidy to cleanup generated html

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'jekyll'
 gem 'jekyll-last-modified-at'
 gem 'jekyll-redirect-from'
 gem 'jekyll-sitemap'
+gem 'jekyll-tidy'
 gem 'kramdown-math-katex'
 gem 'nokogumbo'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,8 @@ GEM
       rainbow (~> 3.0)
       typhoeus (~> 1.3)
       yell (~> 2.0)
+    htmlbeautifier (1.3.1)
+    htmlcompressor (0.4.0)
     http_parser.rb (0.6.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -52,6 +54,10 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-tidy (0.2.2)
+      htmlbeautifier
+      htmlcompressor
+      jekyll
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     katex (0.8.0)
@@ -111,6 +117,7 @@ DEPENDENCIES
   jekyll-last-modified-at
   jekyll-redirect-from
   jekyll-sitemap
+  jekyll-tidy
   kramdown-math-katex
   nokogumbo
 

--- a/config-templates/_config.global.yml
+++ b/config-templates/_config.global.yml
@@ -51,6 +51,7 @@ plugins:
   - jekyll-redirect-from
   - jekyll-sitemap
   - jekyll-last-modified-at
+  - jekyll-tidy
 
 # Set custom markdown processor for glossary tag expansion
 markdown: FaktaOKlimatuProcessor


### PR DESCRIPTION
Closes #18 

I have found this plugin that cleans up the generated HTML. The generated code looks good. Let me know if you like it as well.

I have compared generated `index.html` to make sure it does not break something and quickly went through a bunch of pages as well. But please take a look with your trained eye.

Thanks!