### PR TITLE
#81: Replacing tidy with local plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'jekyll'
 gem 'jekyll-last-modified-at'
 gem 'jekyll-redirect-from'
 gem 'jekyll-sitemap'
-gem 'jekyll-tidy'
+gem 'htmlbeautifier'
 gem 'kramdown-math-katex'
 gem 'nokogumbo'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,6 @@ GEM
       typhoeus (~> 1.3)
       yell (~> 2.0)
     htmlbeautifier (1.3.1)
-    htmlcompressor (0.4.0)
     http_parser.rb (0.6.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -54,10 +53,6 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-tidy (0.2.2)
-      htmlbeautifier
-      htmlcompressor
-      jekyll
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     katex (0.8.0)
@@ -114,11 +109,11 @@ DEPENDENCIES
   execjs
   ffi-icu
   html-proofer
+  htmlbeautifier
   jekyll
   jekyll-last-modified-at
   jekyll-redirect-from
   jekyll-sitemap
-  jekyll-tidy
   kramdown-math-katex
   nokogumbo
   webrick (~> 1.7)

--- a/_config.global.yml
+++ b/_config.global.yml
@@ -51,10 +51,14 @@ plugins:
   - jekyll-redirect-from
   - jekyll-sitemap
   - jekyll-last-modified-at
-#  - jekyll-tidy # Temporarily disabled as it breaks search
 
 # Set custom markdown processor for glossary tag expansion
 markdown: FaktaOKlimatuProcessor
 
 target-blank:
     add_css_classes: ext-link
+
+html-beautify:
+  include:
+    - "*.html"
+    - "*.md"

--- a/_plugins/html-beautify.rb
+++ b/_plugins/html-beautify.rb
@@ -1,0 +1,33 @@
+require "jekyll"
+require "htmlbeautifier"
+
+module Jekyll
+  module Beautify
+    def self.init(site)
+      config = site.config
+      @include_paths = (config["html-beautify"] && config["html-beautify"]["include"]) || []
+    end
+
+    def self.include?(path)
+      return @include_paths.any? { |pattern| File.fnmatch(pattern, path) }
+    end
+
+    def self.process(output)
+      return HtmlBeautifier.beautify output
+    end
+  end
+
+  Hooks.register :site, :after_reset do |jekyll|
+    Jekyll::Beautify.init(jekyll)
+  end
+
+  Hooks.register :documents, :post_render do |doc|
+    next if !Jekyll::Beautify::include?(doc.relative_path)
+    doc.output = Jekyll::Beautify::process(doc.output)
+  end
+
+  Hooks.register :pages, :post_render do |page|
+    next if !Jekyll::Beautify::include?(page.relative_path)
+    page.output = Jekyll::Beautify::process(page.output)
+  end
+end


### PR DESCRIPTION
Closes #81 

I don't like that jekyll-tidy allows only to exclude files instead of including specific ones. So I got inspired by it and wrote a small plugin of our own.

I've compared all the generated files before and after (including the tree itself). Only HTML files are affected. I also checked the content of the files. It all seems fine. The beautifier will break inline JS if we ever want to do that but that would be discovered during dev.