### PR TITLE
Fix build with Ruby 3+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,6 @@ gem 'nokogumbo'
 # Temporarity provided locally.
 # Local fix applied (URI escaping needed). Pull request submitted.
 # gem 'jekyll-target-blank'
+
+# Temporary workaround enabling build with Ruby 3+ (e.g. Fedora 34)
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
     yell (2.2.2)
 
 PLATFORMS
@@ -120,6 +121,7 @@ DEPENDENCIES
   jekyll-tidy
   kramdown-math-katex
   nokogumbo
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.4
+   2.2.15


### PR DESCRIPTION
Temporarily add webrick as an explicit dependency. Fixes build on Fedora 34.

@mgrabovsky, @jankrcal, mohli by ste prosim vyskusat, ze aj build na starsom prostredi funguje OK, aby som to touto zmenou nerozbil ostatnym?