### PR TITLE
Transition newsletter to Ecomail

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div>
             {% if site.newsletter %}
-            <a class="no-ext-link-icon" href="{{ site.newsletter }}">
+            <a class="no-ext-link-icon" href="#newsletter-modal" id="newsletter-embed" data-toggle="modal" data-target="#newsletter-modal">
             <span class="fas fa-fw fa-envelope-open-text"></span> {{ site.data.lang.footer.get-newsletter }}</a><br/>
             {% endif %}
             {% if site.fundraising %}

--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -1,0 +1,12 @@
+<div class="modal fade" id="newsletter-modal" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-body">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <div id="f-{{ site.newsletter }}"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -1,4 +1,4 @@
-<div class="modal fade" id="newsletter-modal" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-hidden="true">
+<div class="modal fade" id="newsletter-modal" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-hidden="true" data-newsletter-id="{{ site.newsletter }}">
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-body">

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -4,6 +4,8 @@
 <script src="{{ site.cdn.fuse }}" integrity="{{ site.cdn.fuse_hash }}" crossorigin="anonymous"></script>
 <script src="/assets/js/search.js"></script>
 <script src="/assets/js/main.js"></script>
+<script src="/assets/js/newsletter.js"></script>
+{% include newsletter.html %}
 {% if jekyll.environment == "production" %}
 {% include includes-local/website-analytics-noscript.html %}
 {% endif %}

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -187,3 +187,15 @@ a.card:hover {
     height: 100px;
     padding: 10px 0 10px 30px;
 }
+
+// Newsletter pop-up
+
+#newsletter-modal {
+    .modal-content {
+        background-color: $c-extralight-blue;
+    }
+
+    button.close {
+        margin-bottom: -16px;
+    }
+}

--- a/assets/js/newsletter.js
+++ b/assets/js/newsletter.js
@@ -1,0 +1,15 @@
+---
+# Empty front matter to enable Jekyll processing
+---
+$("#newsletter-modal").on('shown.bs.modal', function(w, d, s, o, f, js, fjs) {
+    w['ecm-widget'] = o;
+    w[o] = w[o] || function() {
+        (w[o].q = w[o].q || []).push(arguments)
+    };
+    js = d.createElement(s), fjs = d.getElementsByTagName(s)[0];
+    js.id = '{{ site.newsletter }}';
+    js.dataset.a = 'faktaoklimatu';
+    js.src = f;
+    js.async = 1;
+    fjs.parentNode.insertBefore(js, fjs);
+}(window, document, 'script', 'ecmwidget', 'https://d70shl7vidtft.cloudfront.net/widget.js'));

--- a/assets/js/newsletter.js
+++ b/assets/js/newsletter.js
@@ -1,15 +1,17 @@
----
-# Empty front matter to enable Jekyll processing
----
-$("#newsletter-modal").on('shown.bs.modal', function(w, d, s, o, f, js, fjs) {
-    w['ecm-widget'] = o;
-    w[o] = w[o] || function() {
-        (w[o].q = w[o].q || []).push(arguments)
-    };
-    js = d.createElement(s), fjs = d.getElementsByTagName(s)[0];
-    js.id = '{{ site.newsletter }}';
-    js.dataset.a = 'faktaoklimatu';
-    js.src = f;
-    js.async = 1;
-    fjs.parentNode.insertBefore(js, fjs);
-}(window, document, 'script', 'ecmwidget', 'https://d70shl7vidtft.cloudfront.net/widget.js'));
+$(document).ready(() => {
+    $('#newsletter-modal').one('show.bs.modal', (event) => {
+        const newsletterId = event.target.dataset.newsletterId;
+
+        window['ecm-widget'] = 'ecmwidget';
+        window['ecmwidget'] = window['ecmwidget'] || function() {
+            (window['ecmwidget'].q = window['ecmwidget'].q || []).push(arguments)
+        };
+
+        const js = document.createElement('script');
+        js.id = newsletterId;
+        js.dataset.a = 'faktaoklimatu';
+        js.src = 'https://d70shl7vidtft.cloudfront.net/widget.js';
+
+        document.head.appendChild(js);
+    });
+});

--- a/deploy-templates/firebase.json
+++ b/deploy-templates/firebase.json
@@ -45,7 +45,7 @@
           "value": "{\"report_to\": \"default\", \"max_age\": 2592000, \"include_subdomains\": true, \"failure_fraction\": 1.0}"
         }, {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "default-src 'self'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://cdnjs.cloudflare.com; style-src 'self' https://cdnjs.cloudflare.com; style-src-attr 'self' 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com; frame-src https://www.googletagmanager.com; report-uri {{ CORS_REPORT_URI }}/reports/report; report-to default"
+          "value": "default-src 'self'; font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com https://ecomail-accounts.s3.eu-west-1.amazonaws.com; script-src 'self' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://cdnjs.cloudflare.com https://d70shl7vidtft.cloudfront.net; style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-attr 'self' 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com https://r71z7bzeb1.execute-api.eu-west-1.amazonaws.com; frame-src https://www.googletagmanager.com; report-uri {{ CORS_REPORT_URI }}/reports/report; report-to default"
         }, {
           "key": "Expect-CT",
           "value": "max-age=86400,report-uri=\"{{ CORS_REPORT_URI }}/reports/report\""
@@ -97,7 +97,7 @@
           "value": "{\"report_to\": \"default\", \"max_age\": 2592000, \"include_subdomains\": true, \"failure_fraction\": 1.0}"
         }, {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "default-src 'self'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://cdnjs.cloudflare.com; style-src 'self' https://cdnjs.cloudflare.com; style-src-attr 'self' 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com; frame-src https://www.googletagmanager.com"
+          "value": "default-src 'self'; font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com https://ecomail-accounts.s3.eu-west-1.amazonaws.com; script-src 'self' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://cdnjs.cloudflare.com https://d70shl7vidtft.cloudfront.net; style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-attr 'self' 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com https://r71z7bzeb1.execute-api.eu-west-1.amazonaws.com; frame-src https://www.googletagmanager.com"
         }, {
           "key": "Expect-CT",
           "value": "max-age=86400"


### PR DESCRIPTION
* Add a modal and script loading Ecomail form.
* CSP violations still need to be addressed.
* Temporary preview available at https://cz-fakta-o-klimatu--preview-newsletter-ecomail-nncd42bv.web.app/

* [x] I wanted to run the JS loading the form only after showing the modal, but I suspect it still runs at page load. Can anyone more skilled in JS please have a look at it? (@ufonzak?)
* [x] The widget domain is still not listed in CSP.
* [x] Double opt-in email still needs to be configured (sorting that out with Anicka in web-cz PR).