### PR TITLE
Factor navbar height out to a variable

### DIFF
--- a/assets/_scss/core_design.scss
+++ b/assets/_scss/core_design.scss
@@ -1,5 +1,6 @@
 html {
-    scroll-padding-top: 7rem;
+    --navbar-height: 5rem;
+    scroll-padding-top: var(--navbar-height);
 }
 
 body {

--- a/assets/_scss/infographic.scss
+++ b/assets/_scss/infographic.scss
@@ -140,7 +140,7 @@ p.caption {
     .sticky-toc {
         position: sticky;
         position: -webkit-sticky;
-        top: 56px;
+        top: var(--navbar-height);
         left: 100px;
     }
 }


### PR DESCRIPTION
This changes unifies the assumed height of navbar across two occurrences and thereby solves

* navbar obscuring the TOC (#51) and
* heading being located lower than expected on the screen.

Resolves #51

![before-after](https://user-images.githubusercontent.com/134321/121707039-78986f00-cad6-11eb-9ddc-15664dfb69e9.png)
