### PR TITLE
Add support for responsive figures

### DIFF
--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -1,6 +1,12 @@
 <div class="longread-figure">
   <a href="/assets-local/figures/{{ page.slug }}/{{ include.name }}">
-    <img src="/assets-local/figures/{{ page.slug }}/{{ include.name }}" alt="{{ include.alt }}">
+    <picture>
+      {%- if include.name-mobile %}
+      <source media="(max-width: 767px)" srcset="/assets-local/figures/{{ page.slug }}/{{ include.name-mobile }}">
+      <source media="(min-width: 768px)" srcset="/assets-local/figures/{{ page.slug }}/{{ include.name }}">
+      {%- endif %}
+      <img src="/assets-local/figures/{{ page.slug }}/{{ include.name }}" alt="{{ include.alt }}">
+    </picture>
   </a>
   {%- if include.caption or (include.source-text and include.source-url) %}
   <div class="source">

--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -3,7 +3,6 @@
     <picture>
       {%- if include.name-mobile %}
       <source media="(max-width: 767px)" srcset="/assets-local/figures/{{ page.slug }}/{{ include.name-mobile }}">
-      <source media="(min-width: 768px)" srcset="/assets-local/figures/{{ page.slug }}/{{ include.name }}">
       {%- endif %}
       <img src="/assets-local/figures/{{ page.slug }}/{{ include.name }}" alt="{{ include.alt }}">
     </picture>


### PR DESCRIPTION
Allow specifying filename for a mobile version of a figure. This will be displayed on screens smaller than 768px in width (medium breakpoint in Bootstrap).

Resolves #88

@mukrop Does this look OK to you?