### PR TITLE
#28 infographics resolution optimization

### DIFF
--- a/_layouts/infographic.html
+++ b/_layouts/infographic.html
@@ -14,8 +14,9 @@
         {% assign download_path = "/assets/generated/" | append: page.slug %}
         <div class="row">
           <div class="col-lg-9">
-            <a class="infographic" id="infographic-fullscreen" href="{{ download_path }}_1920.png">
-              <img class="infographic" src="{{ download_path }}_1200.png" alt="{{ page.title }}">
+            <a class="infographic" id="infographic-fullscreen" href="{{ download_path }}_6000.png">
+              <img class="infographic" src="{{ download_path }}_1920.png" alt="{{ page.title }}"
+                srcset="{{ download_path }}_600.png 600w, {{ download_path }}_1200.png 1200w, {{ download_path }}_1920.png 1920w, {{ download_path }}_6000.png 6000w"/>
             </a>
             <hr/>
             <p class="caption">{{ page.caption }}</p>


### PR DESCRIPTION
Specifying the whole srcset so that browser can decide what resolution to load. I've changed the href to the highest resolution as I'd assume you want to best quality if you want to download it.

I've tested it in chrome with different resolutions. I could not quite get it to load 600, it would load always at least 1200. I think that's fine.

