### PR TITLE
Improve space replacement plugin

### DIFF
--- a/_plugins/space-replacement.rb
+++ b/_plugins/space-replacement.rb
@@ -4,11 +4,11 @@ Jekyll::Hooks.register :site, :post_render do |site|
   Jekyll.logger.info  "                  * Replacing special spaces ..."
 
   def replace!(content)
-    # Thin spaces before groups of digits.
-    content.gsub!(/(?<=\d) (\d{3})/, '&#8239;\1')
-    # Non-breaking spaces before units.
-    content.gsub!(/(?<=\d) (%|‰|€|$|°C|ppm|kg|mil\.)/, '&nbsp;\1')
-    content.gsub!(/(?<=\d) ([kMGT]?(?:t CO|Wh?))/, '&nbsp;\1')
+    # Narrow no-break space between groups of digits.
+    content.gsub!(/(?<=\d) (\d{3})\b/, "\u202f\\1")
+    # No-break space before units.
+    content.gsub!(/(?<=\d) (%|‰|€|$|°C|ppm|kg|k?m|mil\.)/, "\u00a0\\1")
+    content.gsub!(/(?<=\d) ([kMGT]?(?:t CO|Wh?))\b/, "\u00a0\\1")
   end
 
   site.documents.each do |page|


### PR DESCRIPTION
* Use Unicode glyphs in place of HTML entities. This is functionally equivalent and semantically more correct –  we can now use `\s` to match on the space (if we ever need to).
* Add extra checks for word boundaries to avoid false positives.
* Add ‘m’ and ‘km’ to list of units.