### PR TITLE
Adding fancybox to figures and infographics

### DIFF
--- a/_config.global.yml
+++ b/_config.global.yml
@@ -17,6 +17,10 @@ cdn:
     tocbot_hash:        "sha512-8u1QblAcGUuhEv26YgTYO3+OtPL7l37qiYoPQtahVTaiLn/H3Z/K16TOXJ3U7PDYBiJWCWKM0a+ELUDGDgED2Q=="
     fuse:               "https://cdnjs.cloudflare.com/ajax/libs/fuse.js/6.4.6/fuse.min.js"
     fuse_hash:          "sha512-KnvCNMwWBGCfxdOtUpEtYgoM59HHgjHnsVGSxxgz7QH1DYeURk+am9p3J+gsOevfE29DV0V+/Dd52ykTKxN5fA=="
+    fancyapps_js:       "https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.js"
+    fancyapps_js_hash:  "sha512-uURl+ZXMBrF4AwGaWmEetzrd+J5/8NRkWAvJx5sbPSSuOb0bZLqf+tOzniObO00BjHa/dD7gub9oCGMLPQHtQA=="
+    fancyapps_css:      "https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.css"
+    fancyapps_css_hash: "sha512-H9jrZiiopUdsLpg94A333EfumgUBpO9MdbxStdeITo+KEIMaNfHNvwyjjDJb+ERPaRS6DpyRlKbvPUasNItRyw=="
 
 # What files to include/exclude from final site?
 include: [ ".well-known" ] # .well-known-templates implicitly excluded

--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -1,5 +1,5 @@
 <div class="longread-figure">
-  <a href="/assets-local/figures/{{ page.slug }}/{{ include.name }}">
+  <a href="/assets-local/figures/{{ page.slug }}/{{ include.name }}" data-fancybox>
     <picture>
       {%- if include.name-mobile %}
       <source media="(max-width: 767px)" srcset="/assets-local/figures/{{ page.slug }}/{{ include.name-mobile }}" />

--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -4,8 +4,8 @@
     {%- if suffix == "svg" %}
     data-type="iframe"
     {%- endif %}
-    {%- if include.caption %}
-    data-options='{ "caption": {{ include.caption | jsonify }} }'
+    {%- if include.caption or (include.source-text and include.source-url) %}
+    data-caption="..."
     {%- endif %}>
     <picture>
       {%- if include.name-mobile %}
@@ -15,7 +15,7 @@
     </picture>
   </a>
   {%- if include.caption or (include.source-text and include.source-url) %}
-  <div class="source">
+  <div class="source fancybox-custom-caption">
     {%- if include.caption %}
       {{- include.caption }} 
     {%- endif %}

--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -1,10 +1,12 @@
 <div class="longread-figure">
-  <a href="/assets-local/figures/{{ page.slug }}/{{ include.name }}" data-fancybox 
-    data-options='{
-      {%- if include.caption -%}
-      "caption": {{ include.caption | jsonify }}
-      {%- endif -%}
-    }'>
+  <a href="/assets-local/figures/{{ page.slug }}/{{ include.name }}" data-fancybox
+    {%- assign suffix = include.name | split:'.' | last %}
+    {%- if suffix == "svg" %}
+    data-type="iframe"
+    {%- endif %}
+    {%- if include.caption %}
+    data-options='{ "caption": {{ include.caption | jsonify }} }'
+    {%- endif %}>
     <picture>
       {%- if include.name-mobile %}
       <source media="(max-width: 767px)" srcset="/assets-local/figures/{{ page.slug }}/{{ include.name-mobile }}" />

--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -1,5 +1,10 @@
 <div class="longread-figure">
-  <a href="/assets-local/figures/{{ page.slug }}/{{ include.name }}" data-fancybox>
+  <a href="/assets-local/figures/{{ page.slug }}/{{ include.name }}" data-fancybox 
+    data-options='{
+      {%- if include.caption -%}
+      "caption": {{ include.caption | jsonify }}
+      {%- endif -%}
+    }'>
     <picture>
       {%- if include.name-mobile %}
       <source media="(max-width: 767px)" srcset="/assets-local/figures/{{ page.slug }}/{{ include.name-mobile }}" />

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -54,6 +54,7 @@
 <link href="/assets/fonts/source-sans-pro.css" rel="stylesheet">
 <link href="{{ site.cdn.fa }}" rel="stylesheet" integrity="{{ site.cdn.fa_hash }}" crossorigin="anonymous">
 <link href="{{ site.cdn.katex_css }}" rel="stylesheet" integrity="{{ site.cdn.katex_css_hash }}" crossorigin="anonymous">
+<link href="{{ site.cdn.fancyapps_css }}" rel="stylesheet" integrity="{{ site.cdn.fancyapps_css_hash }}" crossorigin="anonymous"/>
 
 <link rel="icon" type="image/png" href="/assets/favicon.png">
 <link rel="canonical" href="{{ page.url | absolute_url }}" />

--- a/_includes/js/fancybox.js
+++ b/_includes/js/fancybox.js
@@ -1,31 +1,14 @@
 (function() {
-  const i18n = {
-    cs: {
-      CLOSE: 'Zavřít',
-      NEXT: 'Další',
-      PREV: 'Předchozí',
-      DOWNLOAD: 'Stáhnout',
-    },
-    sk: {
-      CLOSE: 'Zavrieť',
-      NEXT: 'Ďalší',
-      PREV: 'Predchádzajúca',
-      DOWNLOAD: 'Stiahnuť',
-    },
-  };
-
   const defaults = $.fancybox.defaults;
-  defaults.lang = window.fakta.lang;
+
+  defaults.lang = {{ site.lang | jsonify }};
+  defaults.i18n[defaults.lang] = {{ site.data.lang.fancybox | jsonify }};
+
   defaults.buttons = [
     'zoom',
     'close',
   ];
-  for (const [lang, values] of Object.entries(i18n)) {
-    defaults.i18n[lang] = {
-      ...defaults.i18n.en,
-      ...values,
-    };
-  }
+
   defaults.beforeLoad = function(instance, current) {
     const customCaption = current.opts.$orig[0].parentElement.querySelector('.fancybox-custom-caption');
     if (customCaption) {

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,10 +1,17 @@
+<script>
+window.fakta = {
+  lang: '{{ site.lang }}',
+};
+</script>
 <script src="{{ site.cdn.jquery }}" integrity="{{ site.cdn.jquery_hash }}" crossorigin="anonymous"></script>
 <script src="{{ site.cdn.bootstrap_js }}" integrity="{{ site.cdn.bootstrap_js_hash }}" crossorigin="anonymous"></script>
 <script src="{{ site.cdn.tocbot }}" integrity="{{ site.cdn.tocbot_hash }}" crossorigin="anonymous"></script>
 <script src="{{ site.cdn.fuse }}" integrity="{{ site.cdn.fuse_hash }}" crossorigin="anonymous"></script>
+<script src="{{ site.cdn.fancyapps_js }}" integrity="{{ site.cdn.fancyapps_js_hash }}" crossorigin="anonymous"></script>
 <script src="/assets/js/search.js"></script>
 <script src="/assets/js/main.js"></script>
 <script src="/assets/js/newsletter.js"></script>
+<script src="/assets/js/fancybox.js"></script>
 {% include newsletter.html %}
 {% if jekyll.environment == "production" %}
 {% include includes-local/website-analytics-noscript.html %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,8 +1,3 @@
-<script>
-window.fakta = {
-  lang: '{{ site.lang }}',
-};
-</script>
 <script src="{{ site.cdn.jquery }}" integrity="{{ site.cdn.jquery_hash }}" crossorigin="anonymous"></script>
 <script src="{{ site.cdn.bootstrap_js }}" integrity="{{ site.cdn.bootstrap_js_hash }}" crossorigin="anonymous"></script>
 <script src="{{ site.cdn.tocbot }}" integrity="{{ site.cdn.tocbot_hash }}" crossorigin="anonymous"></script>
@@ -11,7 +6,7 @@ window.fakta = {
 <script src="/assets/js/search.js"></script>
 <script src="/assets/js/main.js"></script>
 <script src="/assets/js/newsletter.js"></script>
-<script src="/assets/js/fancybox.js"></script>
+<script>{% include js/fancybox.js %}</script>
 {% include newsletter.html %}
 {% if jekyll.environment == "production" %}
 {% include includes-local/website-analytics-noscript.html %}

--- a/_layouts/infographic.html
+++ b/_layouts/infographic.html
@@ -14,7 +14,7 @@
         {% assign download_path = "/assets/generated/" | append: page.slug %}
         <div class="row">
           <div class="col-lg-9">
-            <a class="infographic" id="infographic-fullscreen" href="{{ download_path }}_6000.png">
+            <a class="infographic" id="infographic-fullscreen" href="{{ download_path }}_6000.png" data-fancybox>
               <img class="infographic" src="{{ download_path }}_1920.png" alt="{{ page.title }}"
                 srcset="{{ download_path }}_600.png 600w, {{ download_path }}_1200.png 1200w, {{ download_path }}_1920.png 1920w"
                 sizes="(max-width: 575.98px) 600px, (max-width: 1199.98px) 1200px, 1920px"

--- a/assets/js/fancybox.js
+++ b/assets/js/fancybox.js
@@ -1,0 +1,29 @@
+(function() {
+  const i18n = {
+    cs: {
+      CLOSE: 'Zavřít',
+      NEXT: 'Další',
+      PREV: 'Předchozí',
+      DOWNLOAD: 'Stáhnout',
+    },
+    sk: {
+      CLOSE: 'Zavrieť',
+      NEXT: 'Ďalší',
+      PREV: 'Predchádzajúca',
+      DOWNLOAD: 'Stiahnuť',
+    },
+  };
+
+  const defaults = $.fancybox.defaults;
+  defaults.lang = window.fakta.lang;
+  defaults.buttons = [
+    'download',
+    'close',
+  ];
+  for (const [lang, values] of Object.entries(i18n)) {
+    defaults.i18n[lang] = {
+      ...defaults.i18n.en,
+      ...values,
+    };
+  }
+})();

--- a/assets/js/fancybox.js
+++ b/assets/js/fancybox.js
@@ -17,7 +17,6 @@
   const defaults = $.fancybox.defaults;
   defaults.lang = window.fakta.lang;
   defaults.buttons = [
-    'download',
     'close',
   ];
   for (const [lang, values] of Object.entries(i18n)) {

--- a/assets/js/fancybox.js
+++ b/assets/js/fancybox.js
@@ -26,4 +26,12 @@
       ...values,
     };
   }
+  defaults.beforeLoad = function(instance, current) {
+    const customCaption = current.opts.$orig[0].parentElement.querySelector('.fancybox-custom-caption');
+    if (customCaption) {
+      const captionBody = instance.$refs.caption[0].querySelector('.fancybox-caption__body');
+      captionBody.innerHTML = '';
+      captionBody.appendChild(customCaption.cloneNode(true));
+    }
+  };
 })();

--- a/assets/js/fancybox.js
+++ b/assets/js/fancybox.js
@@ -17,6 +17,7 @@
   const defaults = $.fancybox.defaults;
   defaults.lang = window.fakta.lang;
   defaults.buttons = [
+    'zoom',
     'close',
   ];
   for (const [lang, values] of Object.entries(i18n)) {


### PR DESCRIPTION
Resolves #76 

Adding fancybox. I decided to use version 3.7.2 (opposed to 4.alpha4) because of the download button and stability. The transition to version 4 would not be all that hard if we decide to do so later.
I've added the translation for SK and CS (please check).
I've introduced a new global object `fakta` where we can put information from our templating.
Please let me know if there is another place where the lightbox should go.

Thanks.