### PR TITLE
Drop text justification

### DIFF
--- a/assets/_scss/core_design.scss
+++ b/assets/_scss/core_design.scss
@@ -75,10 +75,6 @@ a {
 
 /* Textual elements */
 
-p, li, dd {
-    text-align: justify;
-}
-
 p:last-child {
     margin-bottom: 0;
 }


### PR DESCRIPTION
Have all text elements align left by default.

Fixes #112