### PR TITLE
Drop dependency on Nokogumbo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'jekyll-redirect-from'
 gem 'jekyll-sitemap'
 gem 'htmlbeautifier'
 gem 'kramdown-math-katex'
-gem 'nokogumbo'
+gem 'nokogiri', '~> 1.12'
 
 # The plugin in the gem repository is ccurrently not maintained.
 # Temporarity provided locally.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,11 +69,11 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    mini_portile2 (2.5.1)
-    nokogiri (1.11.5)
-      mini_portile2 (~> 2.5.0)
+    mini_portile2 (2.6.1)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    nokogiri (1.11.5-x86_64-linux)
+    nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -115,7 +115,7 @@ DEPENDENCIES
   jekyll-redirect-from
   jekyll-sitemap
   kramdown-math-katex
-  nokogumbo
+  nokogiri (~> 1.12)
   webrick (~> 1.7)
 
 BUNDLED WITH

--- a/_plugins/glossary-tag.rb
+++ b/_plugins/glossary-tag.rb
@@ -1,6 +1,6 @@
 # This generator implements the glossary tag (<glossary>)
 
-require 'nokogumbo'
+require 'nokogiri'
 
 module Jekyll
   class GlossaryTag


### PR DESCRIPTION
The Nokogumbo library has been deprecated by Nokogiri 1.12.0 and its whole API has been integrated into the latter. Update our dependencies to directly depend on Nokogiri only.

See sparklemotion/nokogiri#2205 for details.