### PR TITLE
Fix space replacement plugin

### DIFF
--- a/_plugins/space-replacement.rb
+++ b/_plugins/space-replacement.rb
@@ -4,11 +4,14 @@ Jekyll::Hooks.register :site, :post_render do |site|
   Jekyll.logger.info  "                  * Replacing special spaces ..."
 
   def replace!(content)
+    return if content.nil?
     # Narrow no-break space between groups of digits.
     content.gsub!(/(?<=\d) (\d{3})\b/, "\u202f\\1")
-    # No-break space before units.
-    content.gsub!(/(?<=\d) (%|‰|€|$|°C|K|ppm|kg|[kc]?m|mil\.)\b/, "\u00a0\\1")
-    content.gsub!(/(?<=\d) ([kMGT]?(?:t CO|Wh?))\b/, "\u00a0\\1")
+    # No-break space before physical units.
+    content.gsub!(/(?<=\d) (°C|K|ppm|k?g|[kc]?m|[kMGT]?(?:t CO|Wh?))\b/, "\u00a0\\1")
+    # Note that we do not use the word boundary (\b) here as all the final
+    # matching characters are non-word characters.
+    content.gsub!(/(?<=\d) (%|‰|€|\$|mil\.|mld\.)/, "\u00a0\\1")
   end
 
   site.documents.each do |page|
@@ -18,5 +21,4 @@ Jekyll::Hooks.register :site, :post_render do |site|
     end
     replace!(page.output)
   end
-
 end


### PR DESCRIPTION
The word boundary metacharacter (`\b`) matches (zero-length) on either the string boundary or a boundary between a word and a non-word character. Since %, $, etc. are non-word characters, the previous version of the pattern would fail to match on most reasonable instances. For instance, it would match on "50 %x" but not on "50 %.".

Fixes #122