### PR TITLE
Prevent infographics from lazy loading

### DIFF
--- a/_layouts/infographic.html
+++ b/_layouts/infographic.html
@@ -15,7 +15,7 @@
         <div class="row">
           <div class="col-lg-9">
             <a class="infographic" id="infographic-fullscreen" href="{{ download_path }}_6000.png" data-fancybox>
-              <img class="infographic" src="{{ download_path }}_1920.png" alt="{{ page.title }}"
+              <img class="infographic" loading="eager" src="{{ download_path }}_1920.png" alt="{{ page.title }}"
                 srcset="{{ download_path }}_600.png 600w, {{ download_path }}_1200.png 1200w, {{ download_path }}_1920.png 1920w"
                 sizes="(max-width: 575.98px) 600px, (max-width: 1199.98px) 1200px, 1920px"
               />


### PR DESCRIPTION
Resolves #106.
Details: Chrome on Android with Lite mode enabled proactively decides the infographic image is partially covered and thus will not be loaded to save data bandwidth. Setting loading mode to `eager` prevents this behavior.