### PR TITLE
Disabling fancybox on mobile devices.

### DIFF
--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -1,5 +1,5 @@
 <div class="longread-figure">
-  <a href="/assets-local/figures/{{ page.slug }}/{{ include.name }}" data-fancybox
+  <a href="/assets-local/figures/{{ page.slug }}/{{ include.name }}" data-lightbox
     {%- assign suffix = include.name | split:'.' | last %}
     {%- if suffix == "svg" %}
     data-type="iframe"

--- a/_includes/js/fancybox.js
+++ b/_includes/js/fancybox.js
@@ -17,4 +17,8 @@
       captionBody.appendChild(customCaption.cloneNode(true));
     }
   };
+
+  if (!$.fancybox.isMobile) {
+    $('[data-lightbox]').fancybox();
+  }
 })();

--- a/_layouts/infographic.html
+++ b/_layouts/infographic.html
@@ -14,7 +14,7 @@
         {% assign download_path = "/assets/generated/" | append: page.slug %}
         <div class="row">
           <div class="col-lg-9">
-            <a class="infographic" id="infographic-fullscreen" href="{{ download_path }}_6000.png" data-fancybox>
+            <a class="infographic" id="infographic-fullscreen" href="{{ download_path }}_6000.png" data-lightbox>
               <img class="infographic" loading="eager" src="{{ download_path }}_1920.png" alt="{{ page.title }}"
                 srcset="{{ download_path }}_600.png 600w, {{ download_path }}_1200.png 1200w, {{ download_path }}_1920.png 1920w"
                 sizes="(max-width: 575.98px) 600px, (max-width: 1199.98px) 1200px, 1920px"


### PR DESCRIPTION
I only enable lightbox on non-mobile browsers. The check is apparently done testing agent for certain strings. I could also do dynamically based on viewport if you find it nonsufficient.