### PR TITLE
Polish styling of Q&A for topics

### DIFF
--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -96,7 +96,7 @@
               <dl class="qa">
                 {%- for qa in sub.qa %}
                   <dt class="clearfix">
-                    <a data-toggle="collapse" data-target="#collapse-qa-{{ qaCounter }}" aria-expanded="false" aria-controls="collapse-qa-{{ qaCounter }}">
+                    <a class="collapsed" data-toggle="collapse" data-target="#collapse-qa-{{ qaCounter }}" aria-expanded="false" aria-controls="collapse-qa-{{ qaCounter }}">
                       <div>
                         {{ qa.q }}
                         <div class="qa-button">

--- a/assets/_scss/topic.scss
+++ b/assets/_scss/topic.scss
@@ -63,22 +63,33 @@
         visibility: visible;
     }
     .qa {
-        border: 1px solid black;
-
         dt a {
             text-decoration: none;
         }
-        dt:not(:first-of-type) {
-            border-top: 1px solid black;
+        dt a i.fas {
+            transition: .3s transform ease-in-out;
         }
-        dt, dd div {
-            padding: 0.3em 1em;
+        dt a.collapsed i.fas {
+            transform: rotate(0deg);
+        }
+        dt a:not(.collapsed) i.fas {
+            transform: rotate(-180deg);
+        }
+        dt:not(:first-of-type) {
+            border-top: 1px solid rgba(0,0,0,.25);
+        }
+        dt {
+            padding: 0.5em 0.2em;
         }
         dd {
             margin: 0;
+            div {
+                padding: 0em 1.5em 1em 1.5em;
+            }
         }
         .qa-button {
-            float: right;
+            float: left;
+            padding-right: 0.5em;
         }
     }
 }


### PR DESCRIPTION
This PR adds a bit of polish & visual unity to Q&A sections on the pages of topics:
 - trims down borders
 - turns black into light-gray
 - animates the chevron (via css)