### PR TITLE
Fix missing thumbnails in mobile search

### DIFF
--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -81,12 +81,29 @@ a.card:hover {
 .small-card-img-overlay {
     background-color: rgba(255, 255, 255, 0.9);
     top: auto;
-    bottom: 0.5rem;
-    padding: 0.3rem 1rem;
+    bottom: 0.3rem;
+    padding: 0.3rem 0.5rem;
 
     h5 {
         margin-bottom: 0;
-        font-size: 1rem;
+        font-size: 0.9rem;
+        font-weight: normal;
+        i.fas {
+            padding-left: 0.1rem;
+            font-size: 0.7rem;
+        }
+    }
+}
+
+@media (min-width: 768px) {
+    .small-card-img-overlay {
+        bottom: 0.5rem;
+        padding: 0.3rem 1rem;
+
+        h5 {
+            font-size: 1rem;
+            font-weight: bold;
+        }
     }
 }
 

--- a/assets/_scss/search.scss
+++ b/assets/_scss/search.scss
@@ -116,6 +116,13 @@ nav.navbar-search {
                     height: 100%;
                     background: url("/assets-local/favicon.png") 50% 20%/32px no-repeat;
                 }
+
+                div.specific-card {
+                    width: 100%;
+                    height: 100%;
+                    background-size: cover;
+                    background-position: bottom;
+                }
             }
 
             .snippet {
@@ -177,16 +184,8 @@ nav.navbar-search {
                     margin-block: 1rem;
 
                     div.branded-card {
-                        width: 100%;
-                        height: 100%;
                         background-size: 48px;
                         background-position-y: 30%;
-                    }
-                    div.specific-card {
-                        width: 100%;
-                        height: 100%;
-                        background-size: cover;
-                        background-position: bottom;
                     }
                 }
 

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -257,7 +257,9 @@ class Search {
                        `<div class="search-preview card">${item.block}</div>` +
                        `<div class="snippet">${snippet}</div>`;
             let url = `${item.url}?q=${encodeURIComponent(this.searchString)}`;
-            resultsHtml += `<a class="dropdown-item clearfix" href="${url}" tabindex="0">${card}</a>`;
+            let is_url_absolute = /^(?:[a-z]+:)?\/\//i.test(url);
+            let target = is_url_absolute ? ' target="_blank"' : "";
+            resultsHtml += `<a class="dropdown-item clearfix" href="${url}"${target} tabindex="0">${card}</a>`;
         });
         return resultsHtml;
     }


### PR DESCRIPTION
This PR addresses a few minor issues in search:
 - fixes missing thumbnails on mobile (a new style introduced in #168 in search.scss was unintentionally applied only to desktop)
 - tweaks styling of the overlay text on mobile (making it smaller to better fit the small size of the thumbnail; especially important for the longer "Podcast 2050" overlay)
 - makes podcast open in a new window/tab from search (to make the behavior consistent with usages in boxes and elsewhere) - podcasts are detected by the URL being absolute, starting with a URL scheme like "https://"