### PR TITLE
Add check to get_url filter

### DIFF
--- a/_plugins/filter-truncatewords-html.rb
+++ b/_plugins/filter-truncatewords-html.rb
@@ -1,4 +1,4 @@
-require 'nokogumbo'
+require 'nokogiri'
 
 module Jekyll
   module TruncateWordsHtmlFilter

--- a/_plugins/podcast-redirect.rb
+++ b/_plugins/podcast-redirect.rb
@@ -1,6 +1,8 @@
 module Jekyll
   module PodcastRedirectFilter
     def get_url(input)
+      return nil if input.nil?
+
       if input["layout"] == @context.registers[:site].config["podcast-redirect"]["layout"]
         @context.registers[:site].config["podcast-redirect"]["site"] + input.url
       else


### PR DESCRIPTION
Make the `get_url` filter a bit more resilient and return `nil` if the input is `nil`. This prevents unreadable tracebacks when the input is not a document as expected.

\+ Remove import of `nokogumbo` in favour of `nokogiri` (see sparklemotion/nokogiri#2205).