### PR TITLE
Unify design of product cards

### DIFF
--- a/_includes/preview-block.html
+++ b/_includes/preview-block.html
@@ -33,7 +33,7 @@
     {% when 'study' %}
         <div style="background-image: url('/assets/studies/{{ item.slug }}.jpg')" title="{{ site.data.lang.text.explainer.explainer }}: {{ item.title }}" class="preview-card-image img-fluid card-img">
         </div>
-        <div class="card-img-overlay card-title-overlay card-study-overlay">
+        <div class="card-img-overlay card-title-overlay">
             <h5 class="card-title">{{ item.title }}</h5>
             <p class="card-author">{{ item.study-institution }}, {{ item.study-year }}</p>
             <h6 class="card-subtitle">{{ site.data.lang.text.study.study }}</h6>

--- a/_includes/preview-block.html
+++ b/_includes/preview-block.html
@@ -9,8 +9,9 @@
         {%- endunless %}
     {% when 'dataset' %}
         <img src="/assets-local/datasets/{{ item.slug }}.png" alt="{{ site.data.lang.text.dataset.dataset }}: {{ item.title }}" title="{{ site.data.lang.text.dataset.dataset }}: {{ item.title }}" class="img-fluid card-img" />
-        <div class="card-img-overlay card-dataset-overlay">
-          <h5 class="card-title">{{ item.title }}</h5>
+        <div class="card-img-overlay card-title-overlay">
+            <h5 class="card-title">{{ item.title }}</h5>
+            <h6 class="card-subtitle">{{ site.data.lang.text.dataset.dataset }}</h6>
         </div>
         {%- unless include.no_include_tags %}
         <div class="card-img-overlay tags-overlay-box">
@@ -20,9 +21,9 @@
     {% when 'explainer' %}
         <div style="background-image: url('/assets/covers/{{ item.slug }}_600.jpg')" title="{{ site.data.lang.text.explainer.explainer }}: {{ item.title }}" class="preview-card-image img-fluid card-img">
         </div>
-        <div class="card-img-overlay card-dataset-overlay">
-        <h5 class="card-title">{{ item.title }}</h5>
-        <h6 class="card-subtitle">{{ site.data.lang.text.explainer.explainer }}</h6>
+        <div class="card-img-overlay card-title-overlay">
+            <h5 class="card-title">{{ item.title }}</h5>
+            <h6 class="card-subtitle">{{ site.data.lang.text.explainer.explainer }}</h6>
         </div>
         {%- unless include.no_include_tags %}
         <div class="card-img-overlay tags-overlay-box">
@@ -30,10 +31,12 @@
         </div>
         {%- endunless %}
     {% when 'study' %}
-        <div class="card-body">
-            <h5>{{ item.title }}</h5>
-            <p class="text-secondary">{{ item.study-institution }}, {{ item.study-year }}</p>
-            <p class="card-text">{{ item.caption }}</p>
+        <div style="background-image: url('/assets/studies/{{ item.slug }}.jpg')" title="{{ site.data.lang.text.explainer.explainer }}: {{ item.title }}" class="preview-card-image img-fluid card-img">
+        </div>
+        <div class="card-img-overlay card-title-overlay card-study-overlay">
+            <h5 class="card-title">{{ item.title }}</h5>
+            <p class="card-author">{{ item.study-institution }}, {{ item.study-year }}</p>
+            <h6 class="card-subtitle">{{ site.data.lang.text.study.study }}</h6>
         </div>
         {%- unless include.no_include_tags %}
         <div class="card-img-overlay tags-overlay-box">
@@ -42,8 +45,9 @@
         {%- endunless %}
     {% when 'survey' %}
         <div class="card-body">
-            <h5>{{ item.title }}</h5>
-            <p class="card-text mt-3">{{ item.caption }}</p>
+            <h5 class="card-title">{{ item.title }}</h5>
+            <h6 class="card-subtitle">{{ site.data.lang.text.survey.survey }}</h6>
+            <p class="card-text card-survey-caption mt-3">{{ item.caption }}</p>
         </div>
         {%- unless include.no_include_tags %}
         <div class="card-img-overlay tags-overlay-box">
@@ -53,9 +57,9 @@
     {% when 'episode' %}
         <div style="background-image: url('/assets/episodes/{{ item.slug }}.jpg')" title="{{ site.data.lang.text.episodes.episodes }}: {{ item.title }}" class="preview-card-image img-fluid card-img">
         </div>
-        <div class="card-img-overlay card-dataset-overlay">
-        <h5 class="card-title">{{ item.title }}</h5>
-        <h6 class="card-subtitle">{{ site.data.lang.text.episode.episode }} <i class="fas fa-external-link-alt"></i></h6>
+        <div class="card-img-overlay card-title-overlay">
+            <h5 class="card-title">{{ item.title }}</h5>
+            <h6 class="card-subtitle">{{ site.data.lang.text.episode.episode }} <i class="fas fa-external-link-alt"></i></h6>
         </div>
     {% else %}
         <p>Unknown layout.</p>

--- a/_layouts/survey.html
+++ b/_layouts/survey.html
@@ -9,7 +9,7 @@
   <main>
     <div class="section">
       <div class="container">
-        <h1>{{ page.title }}</h1>
+        <h1>{{ site.data.lang.text.survey.survey }}: {{ page.title }}</h1>
         {% include tags.html tags=page.tags link="true" %}
         <p class="lead">{{ page.intro }}</p>
 

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -86,7 +86,7 @@
                 {%- if item %}
                   <div class="col-md-6 col-lg-4">
                     <a href="{{ item | get_url }}" class="preview-card card">
-                      {% include preview-block.html item=item %}
+                      {% include preview-block.html item=item no_include_tags=true %}
                     </a>
                   </div>
                 {%- endif %}

--- a/assets/_scss/core_design.scss
+++ b/assets/_scss/core_design.scss
@@ -1,6 +1,7 @@
 html {
     --navbar-height: 5rem;
     scroll-padding-top: var(--navbar-height);
+    scroll-behavior: smooth;
 }
 
 body {

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -88,7 +88,8 @@ a.card:hover {
 }
 
 .small-card-img-overlay {
-    background-color: rgba(255, 255, 255, 0.9);
+    background-color: rgba(255, 255, 255, 0.925);
+    border-radius: 0;
     top: auto;
     bottom: 0.5rem;
     padding: 0.3rem 1rem;
@@ -100,14 +101,10 @@ a.card:hover {
 }
 
 .card-title-overlay {
-    background-color: rgba(255, 255, 255, 0.9);
+    background-color: rgba(255, 255, 255, 0.925);
     bottom: auto;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-}
-
-.card-study-overlay {
-    background-color: rgba(255, 255, 255, 0.95);
+    border-bottom: 2px solid rgba(0, 0, 0, 0.125);
+    border-radius: 0;
 }
 
 .more-overlay-box {

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -64,6 +64,15 @@
         text-transform: uppercase;
         font-size: 0.9rem;
     }
+    p.card-author {
+        font-size: 0.9rem;
+        color: slategray;
+        margin-top: -.375rem;
+        margin-bottom: 0.5rem;
+    }
+    p.card-survey-caption {
+        font-size: 0.9rem;
+    }
 }
 
 .preview-card-image {
@@ -90,11 +99,15 @@ a.card:hover {
     }
 }
 
-.card-dataset-overlay {
+.card-title-overlay {
     background-color: rgba(255, 255, 255, 0.9);
     bottom: auto;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
+}
+
+.card-study-overlay {
+    background-color: rgba(255, 255, 255, 0.95);
 }
 
 .more-overlay-box {


### PR DESCRIPTION
This PR further unifies the design of cards of individual products (like studies, surveys, etc.).

Notably
 - for studies, their images are now used in the card;
 - for surveys, the "Survey: " prefix is added automatically to the title.

As an unrelated minor fix, smooth scrolling is configured for the whole site (try it on the TOC in any explainer or on any other link within a page).