### PR TITLE
Add a test checking for build errors

### DIFF
--- a/_includes/preview-block-without-link.html
+++ b/_includes/preview-block-without-link.html
@@ -62,5 +62,5 @@
             <h6 class="card-subtitle">{{ site.data.lang.text.episode.episode }} <i class="fas fa-external-link-alt"></i></h6>
         </div>
     {% else %}
-        <div class="build-error">Unknown layout</div>
+        <div class="build-error">Unknown layout ‘{{ item.layout }}’</div>
 {% endcase %}

--- a/_includes/preview-block-without-link.html
+++ b/_includes/preview-block-without-link.html
@@ -62,5 +62,5 @@
             <h6 class="card-subtitle">{{ site.data.lang.text.episode.episode }} <i class="fas fa-external-link-alt"></i></h6>
         </div>
     {% else %}
-        <p>Unknown layout.</p>
+        <div class="build-error">Unknown layout</div>
 {% endcase %}

--- a/_includes/preview-block.html
+++ b/_includes/preview-block.html
@@ -9,9 +9,13 @@
 {%- endif %}
 
 {% assign item = site.infographics | concat: site.studies | concat: site.explainers | concat: site.episodes | find_exp:"item","item.slug == include.slug" %}
-<a href="{{ item | get_url }}" class="preview-card card">
-  {% include preview-block-without-link.html item=item no_include_tags=include.no_include_tags %}
-</a>
+{%- if item %}
+  <a href="{{ item | get_url }}" class="preview-card card">
+    {% include preview-block-without-link.html item=item no_include_tags=include.no_include_tags %}
+  </a>
+{%-else %}
+  <div class="build-error">No item with slug {{ include.slug }}</div>
+{%-endif %}
 
 {%- if include.comment %}
   </div>

--- a/assets/_scss/core_design.scss
+++ b/assets/_scss/core_design.scss
@@ -303,6 +303,10 @@ ul:last-child {
     }
 }
 
+.build-error {
+    color: red;
+}
+
 /* Footer */
 
 footer {

--- a/utils/test.rb
+++ b/utils/test.rb
@@ -1,5 +1,14 @@
 require 'html-proofer'
 
+class CheckBuildErrors < ::HTMLProofer::Check
+    def run
+        @html.css('div.build-error').each do |node|
+            @div = create_element(node)
+            add_issue("Build error", line: @div.line, content: node.inner_html)
+        end
+    end
+end
+
 options = {
     :assume_extension => true,
     :check_favicon => true,


### PR DESCRIPTION
This PR introduces a test that enforces there is no build error log (`DIV.build-error`) in the resulting HTML files.

It also adds first few instances of such error logs in the templates:
 - when an unknown slug is used for a preview block;
 - when an unknown layout is used for a preview block.

In the future, this technique will be used for more types of sanity checks in the code.