### PR TITLE
Improve (mobile) layout of topic pages and the home page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
-<footer>
-    <div class="container">
-        <div>
+<footer class="pb-4">
+    <div class="container"><div class="row">
+        <div class="col-12 col-md-6 mt-4">
             {% if site.newsletter %}
             <a class="no-ext-link-icon" href="#newsletter-modal" id="newsletter-embed" data-toggle="modal" data-target="#newsletter-modal">
             <span class="fas fa-fw fa-envelope-open-text"></span> {{ site.data.lang.footer.get-newsletter }}</a><br/>
@@ -24,7 +24,7 @@
             <a class="no-ext-link-icon" href="mailto:{{ site.email }}">
             <span class="fas fa-fw fa-envelope"></span> {{ site.email }}</a><br/>
         </div>
-        <div class="text-right">
+        <div class="col-12 col-md-6 mt-4 text-md-right">
             {{ site.copyright }}<br/>
             {% if site.data.lang.footer.privacy-policy %}
                 <a href="/gdpr">{{ site.data.lang.footer.privacy-policy }}</a><br/>
@@ -33,5 +33,5 @@
             title="commit {{ site.git.commit_hash_short }}">{{ site.git.commit_date }}</a><br/>
             GitHub: <a class="no-ext-link-icon" href="https://github.com/{{ site.github }}/">{{ site.github }}</a>
         </div>
-    </div>
+    </div></div>
 </footer>

--- a/_includes/preview-block.html
+++ b/_includes/preview-block.html
@@ -1,22 +1,24 @@
-{%- if include.comment %}
-  <div class="card-with-comment">
-    <div class="comment">
-      {%- if include.comment-key %}
-      <div class="card-comment-number">{{ include.comment-key }}</div>
-      {%- endif %}
-      <div class="card-comment-text">{{ include.comment | markdownify }}</div>
+<div class="preview-card-container">
+  {%- if include.comment %}
+    <div class="card-with-comment">
+      <div class="comment">
+        {%- if include.comment-key %}
+        <div class="card-comment-number">{{ include.comment-key }}</div>
+        {%- endif %}
+        <div class="card-comment-text">{{ include.comment | markdownify }}</div>
+      </div>
+  {%- endif %}
+
+  {% assign item = site.infographics | concat: site.studies | concat: site.explainers | concat: site.episodes | find_exp:"item","item.slug == include.slug" %}
+  {%- if item %}
+    <a href="{{ item | get_url }}" class="preview-card card">
+      {% include preview-block-without-link.html item=item no_include_tags=include.no_include_tags %}
+    </a>
+  {%-else %}
+    <div class="build-error">No item with slug {{ include.slug }}</div>
+  {%-endif %}
+
+  {%- if include.comment %}
     </div>
-{%- endif %}
-
-{% assign item = site.infographics | concat: site.studies | concat: site.explainers | concat: site.episodes | find_exp:"item","item.slug == include.slug" %}
-{%- if item %}
-  <a href="{{ item | get_url }}" class="preview-card card">
-    {% include preview-block-without-link.html item=item no_include_tags=include.no_include_tags %}
-  </a>
-{%-else %}
-  <div class="build-error">No item with slug {{ include.slug }}</div>
-{%-endif %}
-
-{%- if include.comment %}
-  </div>
-{%- endif %}
+  {%- endif %}
+</div>

--- a/_includes/preview-blocks.html
+++ b/_includes/preview-blocks.html
@@ -2,30 +2,32 @@
 <div class="row justify-content-md">
 {% for item in include.blocks limit:include.limit %}
     <div class="col-md-6 col-lg-4">
-        {% if forloop.index == include.limit and include.link %}
-            {% if include.link == "news" %}
-                <a href="/{{ site.slugs.news }}" class="preview-card card">
-            {% else %} 
-                <a href="/{{ site.slugs.topics }}/{{ include.link.id }}" class="preview-card card">
+        <div class="preview-card-container">
+            {% if forloop.index == include.limit and include.link %}
+                {% if include.link == "news" %}
+                    <a href="/{{ site.slugs.news }}" class="preview-card card">
+                {% else %}
+                    <a href="/{{ site.slugs.topics }}/{{ include.link.id }}" class="preview-card card">
+                {% endif %}
+            {% else %}
+                <a href="{{ item.url }}" class="preview-card card">
             {% endif %}
-        {% else %}
-            <a href="{{ item.url }}" class="preview-card card">
-        {% endif %}
-        {% include preview-block-without-link.html item=item %}
-        {% if forloop.index == include.limit and include.link %}
-            <div class="card-img-overlay more-overlay-box {% if include.link == "news" %}news-overlay-box{% endif %}">
-                <div>
-                    {% if include.link == "news" %}
-                        <i class="fas fa-newspaper"></i>
-                        <p>{{ site.data.lang.text.index.all-news }}</p>
-                    {% else %}
-                        <i class="fas fa-angle-double-right"></i>
-                        <p>{{ site.data.lang.text.index.all-tag }} <em>{{ include.link.name-long }}</em>...</p>
-                    {% endif %}
+            {% include preview-block-without-link.html item=item %}
+            {% if forloop.index == include.limit and include.link %}
+                <div class="card-img-overlay more-overlay-box {% if include.link == "news" %}news-overlay-box{% endif %}">
+                    <div>
+                        {% if include.link == "news" %}
+                            <i class="fas fa-newspaper"></i>
+                            <p>{{ site.data.lang.text.index.all-news }}</p>
+                        {% else %}
+                            <i class="fas fa-angle-double-right"></i>
+                            <p>{{ site.data.lang.text.index.all-tag }} <em>{{ include.link.name-long }}</em>...</p>
+                        {% endif %}
+                    </div>
                 </div>
-            </div>
-        {% endif %}
-        </a>
+            {% endif %}
+            </a>
+        </div>
     </div>
 {% endfor %}
 </div>

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -96,9 +96,11 @@
         <div class="row justify-content-md-left">
           {% for infographics in sorted_infographics %}
             <div class="col-sm-6 col-md-4 col-lg-3">
-              <a href="{{ infographics.url }}" class="preview-card card">
-                <img src="/assets/generated/{{ infographics.slug }}_600.png" alt="{{ infographics.title }}" title="{{ infographics.title }}" class="img-fluid" />
-              </a>
+              <div class="preview-card-container">
+                <a href="{{ infographics.url }}" class="preview-card card">
+                  {%- include preview-block-without-link.html item=infographics %}
+                </a>
+              </div>
             </div>
           {% endfor %}
         </div>

--- a/assets/_scss/core_design.scss
+++ b/assets/_scss/core_design.scss
@@ -39,9 +39,15 @@ h1, h2, h3, h4, h5, .display-1, .display-2, .display-3 { font-weight: bold; }
 h1 a, h2 a, h3 a, h4 a, h5 a { text-decoration: none; }
 
 // Display versions for the title page
-.display-1 { font-size: 4.5rem; }
-.display-2 { font-size: 2.5rem; text-transform: none; }
-.display-3 { font-size: 1.75em; margin: 0rem}
+.display-1 { font-size: 3rem; }
+.display-2 { font-size: 2rem; text-transform: none; }
+.display-3 { font-size: 1.5em; margin: 0rem}
+
+@media (min-width: 768px) {
+    .display-1 { font-size: 4rem; }
+    .display-2 { font-size: 2.5rem; text-transform: none; }
+    .display-3 { font-size: 1.75em; margin: 0rem}
+}
 
 /* Links */
 
@@ -113,6 +119,16 @@ pre {
     white-space: nowrap;
 }
 
+.lead {
+    font-size: 1.15rem;
+}
+
+@media (min-width: 768px) {
+    .lead {
+        font-size: 1.2rem;
+    }
+}
+
 /* Structure elements: section, ul, table, img text */
 
 .section {
@@ -156,7 +172,7 @@ ul:last-child {
 
 .btn {
     text-decoration: none;
-    margin: 0 0.25em 0.5rem 0.25em;
+    margin: 0.25rem;
 }
 
 .btn-group .btn {
@@ -392,16 +408,9 @@ ul:last-child {
 footer {
     flex-shrink: 1;
     width: 100%;
-    padding-top: 2rem;
-    padding-bottom: 2rem;
     line-height: 1.5rem;
     background: rgba(0,0,0,0.05);
     color: $c-secondary;
-
-    > .container {
-        display: flex;
-        justify-content: space-between;
-    }
 
     a {
         color: $c-secondary;

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -3,6 +3,10 @@
 .intro {
     padding-bottom: 0;
 
+    h1 {
+        line-height: 1.1;
+    }
+
     .tagline {
         text-transform: uppercase;
         text-align: right;
@@ -11,30 +15,31 @@
     }
 
     p {
-        font-size: 1.5rem
+        font-size: 1.3em
     }
 
     p:first-of-type {
         margin-top: -3.5rem;
     }
 
+    .intro-buttons {
+        margin-top: 1.5rem;
+        margin-bottom: 3rem;
+    }
+
     @media screen and (max-width: 768px) {
         .tagline {
             float: none;
-            text-align: center;
+            text-align: left;
             display: inline-block;
             width: 100%;
             word-spacing: 0;
             margin-bottom: 1rem;
         }
 
-        h1 {
-            text-align: center;
-        }
-
         p {
+            font-size: 1.15rem;
             padding-left: 0;
-            text-align: center;
         }
 
         p:first-of-type {
@@ -44,12 +49,33 @@
         form {
             padding-left: 0;
         }
+
+        .intro-buttons {
+            margin-bottom: 1.5rem;
+            margin-inline: -10px;
+            display: flex;
+
+            .btn {
+                font-size: 0.8rem;
+                padding: 0.3rem 0.5rem;
+            }
+
+            .btn-primary {
+                font-size: 0.9rem;
+            }
+        }
     }
 }
 
 .card {
     margin: 15px 0 15px 0;
     border-width: 2px;
+}
+
+.preview-card-container {
+    // Make it smaller on mobile.
+    width: 90%;
+    margin-inline: auto;
 }
 
 .preview-card {
@@ -148,6 +174,10 @@ a.card:hover {
             font-weight: bold;
         }
     }
+
+    .preview-card-container {
+        width: 100%;
+    }
 }
 
 .card-title-overlay {
@@ -184,9 +214,19 @@ a.card:hover {
 
 .nav-tabs .nav-link {
     border: 0;
-    margin: 0 10px 0 0;
-    padding: 0.5em 1em;
+    margin: 0 5px 0 0;
+    padding: 0.5em;
+    font-size: 1.1rem;
     cursor: pointer;
+    text-transform: none;
+}
+
+@media (min-width: 768px) {
+    .nav-tabs .nav-link {
+        margin-right: 10px;
+        padding: 0.5em 1em;
+        font-size: 1.3rem;
+    }
 }
 
 /* Accordion of topics covered */

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -217,6 +217,9 @@ a.card:hover {
 .bg-extralight-red { background: $c-extralight-yellow !important; }
 
 .nav-tabs .nav-link {
+    display: flex;
+    align-items: center;
+    height: 100%;
     border: 0;
     margin: 0 5px 0 0;
     padding: 0.5em;

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -68,7 +68,7 @@
 }
 
 .card {
-    margin: 15px 0 15px 0;
+    margin: 10px 0;
     border-width: 2px;
 }
 
@@ -165,6 +165,10 @@ a.card:hover {
 }
 
 @media (min-width: 768px) {
+    .card {
+        margin-block: 15px;
+    }
+
     .small-card-img-overlay {
         bottom: 0.5rem;
         padding: 0.3rem 1rem;

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -38,7 +38,7 @@
         }
 
         p {
-            font-size: 1.15rem;
+            font-size: 1.1rem;
             padding-left: 0;
         }
 

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -289,8 +289,15 @@ a.card:hover {
 }
 
 .index-logos {
-    height: 100px;
-    padding: 10px 0 10px 30px;
+    max-height: 100px;
+    max-width: 49%;
+    padding: 10px;
+}
+
+@media (min-width: 768px) {
+    .index-logos {
+        padding-left: 30px;
+    }
 }
 
 // Newsletter pop-up

--- a/assets/_scss/topic.scss
+++ b/assets/_scss/topic.scss
@@ -1,11 +1,4 @@
-.topic-intro {
-    margin-bottom: 8rem;
-    font-size: 1.15rem;
-
-    .topic-icon img {
-        width: 100%;
-    }
-}
+/* Dasboards */
 
 .dashboard {
     font-size: 0.9rem;
@@ -190,6 +183,17 @@
     }
 }
 
+/* Page intro and subtopics */
+
+.topic-intro {
+    margin-bottom: 2rem;
+    font-size: 1.1rem;
+
+    .topic-icon img {
+        width: 100%;
+    }
+}
+
 .subtopic {
     font-size: 1.1rem;
 
@@ -200,10 +204,9 @@
     h2:hover .section-link {
         visibility: visible;
     }
-    .subtopic-intro {
-        font-size: 1.15rem;
-    }
+
     .qa {
+        font-size: 1rem;
         dt {
             padding: 0.5em 0.2em;
             a {
@@ -241,6 +244,12 @@
 @media (min-width: 768px) {
     .topic-map img {
         width: 80%;
+    }
+    .subtopic .qa {
+        font-size: 1.1rem;
+    }
+    .topic-intro, .subtitle .subtopic-intro {
+        font-size: 1.15rem;
     }
 }
 


### PR DESCRIPTION
This PR achieves a few changes:
1. shows preview boxes at 90% width, instead of 100% (which needs injecting one more div container)
2. improves the mobile layout of the home page significantly; notably this includes:
     - decreasing the huge font sizes for the home page (so far only for mobile)
     - compressing the top area with our claim
     - making the top buttons fit on one row (slightly questionable as the font is now relatively small)
     - putting the tabs on one row (needs small font but I really want this)
     - making the footer readable
4. generic minor adjustments of spacing on topic pages.

Especially for the point 2, corresponding changes are needed in the language version of the site.