### PR TITLE
[Topic pages] Fix flickr on mobile navbar

### DIFF
--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -7,8 +7,8 @@
 <body>
   {% include navigation.html %}
   <main>
-    <div id="{{ site.data.lang.navigation.first-id }}" class="section pb-1">
-      <div class="container clearfix">
+    <div id="{{ site.data.lang.navigation.first-id }}" class="section pb-0">
+      <div class="container clearfix between-navbars">
         <h1>{{ page.title }}</h1>
       </div>
     </div>

--- a/assets/_scss/core_design.scss
+++ b/assets/_scss/core_design.scss
@@ -293,14 +293,22 @@ ul:last-child {
     }
 }
 
+.between-navbars {
+    // Make it below navbar but above #secondary-navbar (which uses negative margin so it would overlap, otherwise).
+    position: relative;
+    z-index: calc(var(--navbar-zindex) - 2);
+}
+
 #secondary-navbar {
     background-color: white;
     transition: all 300ms ease-out;
     transition-property: top, background-color, box-shadow;
-    padding-block: 0.3rem;
+    padding-block: 0 0.3rem;
     font-size: 1rem;
     position: sticky;
-    z-index: calc(var(--navbar-zindex) - 1);
+    z-index: calc(var(--navbar-zindex) - 3);
+    // Compensate a bit for the invisible .page-title.
+    margin-top: -1rem;
 
     ul {
         display: flex;
@@ -324,10 +332,8 @@ ul:last-child {
 
     .page-title {
         font-weight: bold;
-        height: 0;
         opacity: 0;
         transition: opacity 300ms ease-out;
-        overflow: hidden;
     }
 
     a {
@@ -343,9 +349,10 @@ ul:last-child {
 #secondary-navbar.secondary-navbar-stuck {
     box-shadow: 0 3px 10px #e2e2ff;
     background-color: $c-body;
+    // Make it cover .between-navbars to make the two navbars feel as one.
+    z-index: calc(var(--navbar-zindex) - 1);
 
     .page-title {
-        height: auto;
         opacity: 1;
     }
 }

--- a/assets/js/navbar.js
+++ b/assets/js/navbar.js
@@ -49,7 +49,7 @@ class Navbars {
       var primaryNavHeight = this.primaryNav.outerHeight();
       this.secondaryNav.css('top',
         navbarsVisible
-          ? 'calc(' + Math.floor(primaryNavHeight) + 'px - 0.2rem)'
+          ? 'calc(' + primaryNavHeight + 'px - 0.2rem)'
           : this.getTopForHiddenElement(this.secondaryNav));
 
       if (navbarsVisible && this.isSecondaryNavStuck()) {

--- a/assets/js/navbar.js
+++ b/assets/js/navbar.js
@@ -34,7 +34,6 @@ class Navbars {
     if (this.frozenUpdates) {
       return;
     }
-    var primaryNavHeight = this.primaryNav.outerHeight();
     var navbarsVisible = this.areNavbarsVisible();
 
     this.primaryNav.css('top', navbarsVisible ? 0 : this.getTopForHiddenElement(this.primaryNav));
@@ -47,9 +46,10 @@ class Navbars {
     }
 
     if (this.secondaryNav) {
+      var primaryNavHeight = this.primaryNav.outerHeight();
       this.secondaryNav.css('top',
         navbarsVisible
-          ? 'calc(' + primaryNavHeight + 'px - 0.5rem)'
+          ? 'calc(' + Math.floor(primaryNavHeight) + 'px - 0.2rem)'
           : this.getTopForHiddenElement(this.secondaryNav));
 
       if (navbarsVisible && this.isSecondaryNavStuck()) {
@@ -97,7 +97,6 @@ class Navbars {
     if (this.secondaryNav) {
       offset += this.secondaryNav.outerHeight();
     }
-    console.log(offset)
     return offset;
   }
 
@@ -116,12 +115,6 @@ class Navbars {
       return false;
     }
     var secondaryTop = this.secondaryNav[0].getBoundingClientRect().top;
-
-    // Push the navbar top edge further up (due to the title that's about to appear).
-    if ($("#secondary-navbar .page-title").outerHeight() == 0) {
-      secondaryTop -= 20;
-    }
-
     return secondaryTop <= this.primaryNav.outerHeight();
   }
 


### PR DESCRIPTION
This PR fixes a minor bug in how the two navbars merge on mobile.

The interplay of popping up the small title and counting with its height (before it had any height at all) was too complex. With this PR now:
- the small title is always part of the layout, it's only invisible until the secondary navbar becomes stuck;
- the size of the invisible title is roughly compensated by a negative margin (and a few other minor spacing tweaks here and there);
- the primary title becomes relative with a higher z-index so that it is not covered by the secondary navbar.