### PR TITLE
Further unify use of preview blocks

### DIFF
--- a/_includes/related.html
+++ b/_includes/related.html
@@ -1,11 +1,11 @@
 {% assign related_by_tags = site.documents | where_exp: "item", "'infographics, studies, explainers' contains item.collection"
-| where_exp: "item", "item.tags contains page.tags-topics[0]" | where_exp: "item", "item.slug != page.slug" | sample: 3 %}
+| where_exp: "item", "item.tags contains page.tags-topics[0]" | where_exp: "item", "item.slug != page.slug" | map: "slug" | sample: 3 %}
 {% if related_by_tags.size > 0 %}
 <div class="section">
   <div class="container">
     <h2>{{ site.data.lang.text.related.title }}</h2>
     <p>{{ site.data.lang.text.related.caption }}</p>
-    {% include preview-blocks.html blocks=related_by_tags limit=3 %}
+    {% include preview-blocks-expandable.html slugs=related_by_tags rows=1 %}
   </div>
 </div>
 {% endif %}

--- a/assets/_scss/core_design.scss
+++ b/assets/_scss/core_design.scss
@@ -396,25 +396,29 @@ a.expander.collapsed i.fas {
 
 /* Generic expandable styles */
 
-.expandable-block .expandable {
-    --max-height: 600px;
-    &.expand-always {
-        max-height: var(--max-height) !important;
-    }
-    &.expanding {
-        display: block !important;
-        position: relative;
-        transition: .5s max-height ease-in-out;
-        max-height: 0;
-        overflow: hidden;
-    }
-    &.expanded {
-        display: block !important;
-        max-height: var(--max-height);
+.expandable-block {
+    margin-bottom: 0.5rem;
+
+    .expandable {
+        --max-height: 600px;
+        &.expand-always {
+            max-height: var(--max-height) !important;
+        }
+        &.expanding {
+            display: block !important;
+            position: relative;
+            transition: .5s max-height ease-in-out;
+            max-height: 0;
+            overflow: hidden;
+        }
+        &.expanded {
+            display: block !important;
+            max-height: var(--max-height);
+        }
     }
 }
 
-@media (min-width: 576px) {
+@media (min-width: 768px) {
     .expandable-block .expandable.expand-from-md {
         display: block !important;
         max-height: var(--max-height) !important;

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -54,6 +54,7 @@
             margin-bottom: 1.5rem;
             margin-inline: -10px;
             display: flex;
+            flex-wrap: wrap;
 
             .btn {
                 font-size: 0.8rem;


### PR DESCRIPTION
This PR fixes a minor css bug in expander lists and makes more use of this concept (in related.html).

The only remaining uses of (old) preview-blocks.html are now related to old topic pages (index.md and tag.html).