### PR TITLE
Fix CSP (content security policy)

### DIFF
--- a/deploy-templates/firebase.json
+++ b/deploy-templates/firebase.json
@@ -45,7 +45,7 @@
           "value": "{\"report_to\": \"default\", \"max_age\": 2592000, \"include_subdomains\": true, \"failure_fraction\": 1.0}"
         }, {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "default-src 'self'; font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self' data: https://upload.wikimedia.org https://www.googletagmanager.com https://www.google-analytics.com https://ecomail-accounts.s3.eu-west-1.amazonaws.com; script-src 'self' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://cdnjs.cloudflare.com https://d70shl7vidtft.cloudfront.net; style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-attr 'self' 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com https://r71z7bzeb1.execute-api.eu-west-1.amazonaws.com; frame-src https://www.googletagmanager.com; report-uri {{ CORS_REPORT_URI }}/reports/report; report-to default"
+          "value": "default-src 'self'; font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self' data: https://upload.wikimedia.org https://*.googletagmanager.com https://*.google-analytics.com https://ecomail-accounts.s3.eu-west-1.amazonaws.com; script-src 'self' 'unsafe-eval' https://*.googletagmanager.com https://*.google-analytics.com https://cdnjs.cloudflare.com https://d70shl7vidtft.cloudfront.net; style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-attr 'self' 'unsafe-inline'; connect-src 'self' https://*.google-analytics.com https://r71z7bzeb1.execute-api.eu-west-1.amazonaws.com; frame-src https://*.googletagmanager.com; report-uri {{ CORS_REPORT_URI }}/reports/report; report-to default"
         }, {
           "key": "Expect-CT",
           "value": "max-age=86400,report-uri=\"{{ CORS_REPORT_URI }}/reports/report\""
@@ -97,7 +97,7 @@
           "value": "{\"report_to\": \"default\", \"max_age\": 2592000, \"include_subdomains\": true, \"failure_fraction\": 1.0}"
         }, {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "default-src 'self'; font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com https://ecomail-accounts.s3.eu-west-1.amazonaws.com; script-src 'self' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://cdnjs.cloudflare.com https://d70shl7vidtft.cloudfront.net; style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-attr 'self' 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com https://r71z7bzeb1.execute-api.eu-west-1.amazonaws.com; frame-src https://www.googletagmanager.com"
+          "value": "default-src 'self'; font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self' data: https://*.googletagmanager.com https://*.google-analytics.com https://ecomail-accounts.s3.eu-west-1.amazonaws.com; script-src 'self' 'unsafe-eval' https://*.googletagmanager.com https://*.google-analytics.com https://cdnjs.cloudflare.com https://d70shl7vidtft.cloudfront.net; style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-attr 'self' 'unsafe-inline'; connect-src 'self' https://*.google-analytics.com https://r71z7bzeb1.execute-api.eu-west-1.amazonaws.com; frame-src https://*.googletagmanager.com"
         }, {
           "key": "Expect-CT",
           "value": "max-age=86400"


### PR DESCRIPTION
Google analytics changed server domains from `https://www.google-analytics.com` to `https://region1.google-analytics.com`. To account for more regions, I'm relaxing the policy for GA and GTM to `https://*.google-analytics.com` and `https://*.googletagmanager.com` respectively,