### PR TITLE
Add licence info to the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,6 +26,7 @@
         </div>
         <div class="col-12 col-md-6 mt-4 text-md-right">
             {{ site.copyright }}<br/>
+            <a href="{{ site.data.lang.licence.link }}" title="{{ site.data.lang.licence.title }}" rel="license">{{ site.data.lang.licence.id }}</a>, <a href="/{{ site.slugs.how-to-use }}">{{ site.data.lang.sidebar.share.usage }}</a><br/>
             {% if site.data.lang.footer.privacy-policy %}
                 <a href="/gdpr">{{ site.data.lang.footer.privacy-policy }}</a><br/>
             {% endif %}


### PR DESCRIPTION
This is good practice and also necessary for the National library to publish archives of our website.

Context: The Czech National Library wants to periodically archive our website as one of the Czech best – we already agreed to this. It can also publish and use the archived pages if they have licence information in it. Since we are open, I'm in favor of doing this (and having licence info in the footer seems to be a good idea as we now have more and more objects that are not infographics).
I count on the footer to be redesigned soon anyway (though I think this bit should be kept, although maybe in a more minimalist way).

PS: Unfortunately, my local build is broken and I cannot check the link really looks like it should. I's ask the reviewer to do so, if possible.