### PR TITLE
Minor fixes to homepage design

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,6 +24,9 @@
                 <span class="fab fa-youtube"></span></a></li>
                 {% endif %}
             </ul>
+            {% if site.data.lang.footer.support-us %}
+            <a href="{{ site.fundraising }}" class="btn btn-outline-secondary d-md-none"><i class="fas fa-fw fa-heart"></i> {{ site.data.lang.footer.support-us }}</a>
+            {% endif %}
         </div>
         <div class="col-12 col-md-6 col-lg-4 mt-3 pl-md-5">
             {% if site.data.lang.footer.how-to-use %}

--- a/assets/_scss/core_design.scss
+++ b/assets/_scss/core_design.scss
@@ -268,6 +268,7 @@ ul.arrow {
     }
     #fundraising {
         margin-left: .6rem;
+        margin-block: .4rem;
         padding-inline: .6rem;
     }
     #searchShow, #toggler {
@@ -278,10 +279,11 @@ ul.arrow {
     }
 }
 
-.navbar, .dropdown-menu { font-size: 1.1rem; }
+.navbar, .dropdown-menu { font-size: 1.2rem; }
 
 @media (min-width: 768px) {
     .navbar, .dropdown-menu { font-size: 1rem; }
+    .navbar #fundraising { margin-block: 0; }
 }
 
 @media (min-width: 768px) and (max-width: 992px) {

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -61,15 +61,6 @@
             margin-inline: -10px;
             display: flex;
             flex-wrap: wrap;
-
-            .btn {
-                font-size: 0.8rem;
-                padding: 0.3rem 0.5rem;
-            }
-
-            .btn-primary {
-                font-size: 0.9rem;
-            }
         }
     }
 }

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -44,7 +44,7 @@
         }
 
         p {
-            font-size: 1.1rem;
+            font-size: 1.15rem;
             padding-inline: 0;
         }
 
@@ -247,11 +247,9 @@ a.card:hover {
 /* About us section */
 
 .about-us {
-    font-size: 1.2rem;
     line-height: 1.4;
     .price {
         display: flex;
-        padding: 1.6rem;
         align-items: center;
         line-height: 1.3;
     }

--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -297,6 +297,30 @@ a.card:hover {
     }
 }
 
+/* Accordion of topics covered */
+
+.accordion-item {
+    border-bottom: 1px solid rgba(0,0,0,.25);
+}
+
+.accordion-item:last-child {
+    border: none;
+}
+
+.accordion-header {
+    cursor: pointer;
+    padding: 1rem 0;
+    margin-bottom: 0;
+}
+
+.accordion-header .fa {
+    transition: .3s transform ease-in-out;
+}
+
+.accordion-header.collapsed .fa {
+    transform: rotate(180deg);
+}
+
 /* Tiles for topics */
 
 .topic-tile a {


### PR DESCRIPTION
This PR recovers CSS code deleted (by mistake) in https://github.com/faktaoklimatu/web-core/pull/183/files.

Furthermore, it incorporates minor feedback:
- adds "Support-us" button into the footer (mobile only),
- removes intro buttons custom styling (as they anyway don't fit on one line anymore),
- enlarges navbar fonts and spacing for mobile (for better tappability).