### PR TITLE
More robust Makefile rules for /assets/generated

### DIFF
--- a/.travis.global.yml
+++ b/.travis.global.yml
@@ -40,9 +40,8 @@ cache:
   - $TRAVIS_BUILD_DIR/web-core/assets/generated  # Enable caching of generated infographics
   - $TRAVIS_BUILD_DIR/web-core/assets/studies  # Enable caching of copied study thumbnails
   - $TRAVIS_BUILD_DIR/web-core/assets/covers  # Enable caching of generated explainer covers
-  - $TRAVIS_BUILD_DIR/web-core/assets/episodes  # Enable caching of copied episode covers
 
-before_deploy: 
+before_deploy:
   - wget -q --output-document=web-core/firebase https://firebase.tools/bin/linux/latest
   - chmod +x web-core/firebase
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ TOPICS_SRC=$(wildcard collections/_topics/*.svg)
 TOPICS_DST=$(addprefix $(TOPICS_FOLDER)/,$(notdir $(TOPICS_SRC)))
 INFOGRAPHICS_FOLDER=assets/generated
 INFOGRAPHICS_SRC=$(wildcard collections/_infographics/*/*.pdf collections/_studies/*.pdf)
-INFOGRAPHICS_DST=$(addprefix $(INFOGRAPHICS_FOLDER)/,$(notdir $(INFOGRAPHICS_SRC)))
+INFOGRAPHICS_BASE=$(addprefix $(INFOGRAPHICS_FOLDER)/,$(basename $(notdir $(INFOGRAPHICS_SRC))))
+INFOGRAPHICS_SUFFIXES=.pdf .svg _600.png _1200.png _1920.png _6000.png
+INFOGRAPHICS_DST=$(foreach suffix, $(INFOGRAPHICS_SUFFIXES), $(addsuffix $(suffix),$(INFOGRAPHICS_BASE)))
 DATASETS_FOLDER=assets/datasets
 DATASETS_SRC=$(wildcard collections/_datasets/*.md)
 DATASETS_DST=$(addprefix $(DATASETS_FOLDER)/,$(notdir $(DATASETS_SRC:.md=.png)))
@@ -99,11 +101,11 @@ $(TOPICS_FOLDER)/%: collections/_topics/%
 	mkdir -p $(@D)
 	cp $< $@
 
-$(INFOGRAPHICS_FOLDER)/%.pdf: collections/_infographics/*/%.pdf
-	@utils/convert-infographic.sh $< $@
+$(foreach suffix, $(INFOGRAPHICS_SUFFIXES), $(INFOGRAPHICS_FOLDER)/%$(suffix)): collections/_infographics/*/%.pdf
+	@utils/convert-infographic.sh $< $(addprefix $(INFOGRAPHICS_FOLDER)/,$(notdir $<))
 
-$(INFOGRAPHICS_FOLDER)/%.pdf: collections/_studies/%.pdf
-	@utils/convert-infographic.sh $< $@
+$(foreach suffix, $(INFOGRAPHICS_SUFFIXES), $(INFOGRAPHICS_FOLDER)/%$(suffix)): collections/_studies/%.pdf
+	@utils/convert-infographic.sh $< $(addprefix $(INFOGRAPHICS_FOLDER)/,$(notdir $<))
 
 $(STUDIES_FOLDER)/%: collections/_studies/%
 	mkdir -p $(@D)


### PR DESCRIPTION
This PR makes Makefile rules for generating infographics assets more robust.

Previously, only lack of `/assets/generated/foo.pdf` triggered the script that generated all of these files:
- `/assets/generated/foo.pdf`
- `/assets/generated/foo.svg`
- `/assets/generated/foo_600.png`
- `/assets/generated/foo_1200.png`
- `/assets/generated/foo_1920.png`
- `/assets/generated/foo_6000.png`

After this change, lack of any of these files triggers the script.

As a minor unrelated fix, `/assets/episodes ` gets removed from travis cache because this folder is not used any more in the build process.