### PR TITLE
Remove duplicates from related items

### DIFF
--- a/_includes/related.html
+++ b/_includes/related.html
@@ -8,7 +8,7 @@
         {%- endif %}
     {%- endfor %}
   {%- endfor %}
-  {% assign related_by_tags = related_slugs | split: "|" | compact | where_exp: "item", "item != page.slug" | sample: 3 %}
+  {% assign related_by_tags = related_slugs | split: "|" | compact | uniq | where_exp: "item", "item != page.slug" | sample: 3 %}
 {%- else %}
   {% assign related_by_tags = site.documents | where_exp: "item", "'infographics, studies, explainers' contains item.collection"
 | where_exp: "item", "item.tags contains page.tags-topics[0]" | where_exp: "item", "item.slug != page.slug" | map: "slug" | sample: 3 %}


### PR DESCRIPTION
This PR fixes a minor bug in the "related" tiles.

Before this PR, some content (occurring in multiple related subsections) could show up several times. After this PR, every piece of content appears at most once.

Fixes #206.