### PR TITLE
Remove expander functionality for expaned figures

### DIFF
--- a/_includes/expander.html
+++ b/_includes/expander.html
@@ -1,20 +1,21 @@
-{%- if include.expanded %}
-  {%- assign link-collapsed="" %}
-  {%- assign div-expanded=" show" %}
-{%- else %}
-  {%- assign link-collapsed=" collapsed" %}
-  {%- assign div-expanded="" %}
-{%- endif %}
 <div class="expander-block">
   <h4 class="expander-title {{ include.label-class }}">
-    <a class="expander{{ link-collapsed }}" data-toggle="collapse" data-target="#collapse-figure-{{ include.name }}" aria-expanded="false" aria-controls="collapse-figure-{{ include.name }}">
-      <div class="expander-button">
-        <i class="fas fa-chevron-down"></i>
-      </div>
-      <p>
-        {{ include.label }}
-      </p>
-    </a>
+    {%- if include.expanded %}
+      <span>{{ include.label }}</span>
+    {%- else %}
+      <a class="expander collapsed" data-toggle="collapse" data-target="#collapse-figure-{{ include.name }}" aria-expanded="false" aria-controls="collapse-figure-{{ include.name }}">
+        <div class="expander-button">
+          <i class="fas fa-chevron-down"></i>
+        </div>
+        <span>
+          {{ include.label }}
+        </span>
+      </a>
+    {%- endif %}
   </h4>
-  <div class="expander-body collapse{{ div-expanded }}" id="collapse-figure-{{ include.name }}">{{ include.content | markdownify }}</div>
+  {%- if include.expanded %}
+    <div class="expander-body">{{ include.content | markdownify }}</div>
+  {%- else %}
+    <div class="expander-body collapse" id="collapse-figure-{{ include.name }}">{{ include.content | markdownify }}</div>
+  {%- endif %}
 </div>

--- a/assets/_scss/figure.scss
+++ b/assets/_scss/figure.scss
@@ -41,12 +41,12 @@
     margin-block: 0;
 }
 
-.expander-title a.expander {
+.expander-title span {
     font-size: 1.1rem;
 }
 
-.large-expander-title a.expander {
-    font-size: 1.3rem;
+.large-expander-title span {
+    font-size: 1.2rem;
     font-weight: bold;
 }
 


### PR DESCRIPTION
This commit also makes large expander titles a bit smaller based on feedback from Katka.