### PR TITLE
Convert illustrations into PNGs (for og:image)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /assets/covers/*
 /assets/generated/*
 /assets/studies/*
-/assets/topics/*
+/assets/illustrations/*
 /_config.yml
 /humans.txt
 /robots.txt

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,21 +11,17 @@
 <meta property="og:title" content="{{ page.title }}">
 <meta name="twitter:title" content="{{ page.title }}">
 {% if page.caption %}
-  {% assign caption = page.caption | markdownify | strip_html %}
-  <meta name="description" content="{{ caption }}">
-  <meta property="og:description" content="{{ caption }}">
-  <meta name="twitter:description" content="{{ caption }}">
+  {% assign description = page.caption | markdownify | strip_html %}
 {% elsif page.intro %}
-  {% assign intro = page.intro | markdownify | strip_html %}
-  <meta name="description" content="{{ intro }}">
-  <meta property="og:description" content="{{ intro }}">
-  <meta name="twitter:description" content="{{ intro }}">
+  {% assign description = page.intro | markdownify | strip_html %}
+{% elsif page.perex %}
+  {% assign description = page.perex | markdownify | strip_html %}
 {% else %}
   {% assign description = page.description | markdownify | strip_html %}
-  <meta name="description" content="{{ description }}">
-  <meta property="og:description" content="{{ description }}">
-  <meta name="twitter:description" content="{{ description }}">
 {% endif %}
+<meta name="description" content="{{ description }}">
+<meta property="og:description" content="{{ description }}">
+<meta name="twitter:description" content="{{ description }}">
 <meta name="twitter:card" content="summary_large_image">
 {% case page.layout %}
 {% when 'infographic' %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -31,6 +31,8 @@
   {% assign social_image = "/assets/studies/" | append: page.slug | append: ".jpg" %}
 {% when 'explainer' %}
   {% assign social_image = "/assets/covers/" | append: page.slug | append: ".jpg" %}
+{% when 'topic', 'publication' %}
+  {% assign social_image = "/assets/illustrations/" | append: page.slug | append: "_1200.png" %}
 {% else %}
   {% assign social_image = "/assets-local/img/preview.png" %}
 {% endcase %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,17 +11,20 @@
 <meta property="og:title" content="{{ page.title }}">
 <meta name="twitter:title" content="{{ page.title }}">
 {% if page.caption %}
-  <meta name="description" content="{{ page.caption }}">
-  <meta property="og:description" content="{{ page.caption }}">
-  <meta name="twitter:description" content="{{ page.caption }}">
+  {% assign caption = page.caption | markdownify | strip_html %}
+  <meta name="description" content="{{ caption }}">
+  <meta property="og:description" content="{{ caption }}">
+  <meta name="twitter:description" content="{{ caption }}">
 {% elsif page.intro %}
-  <meta name="description" content="{{ page.intro }}">
-  <meta property="og:description" content="{{ page.intro }}">
-  <meta name="twitter:description" content="{{ page.intro }}">
+  {% assign intro = page.intro | markdownify | strip_html %}
+  <meta name="description" content="{{ intro }}">
+  <meta property="og:description" content="{{ intro }}">
+  <meta name="twitter:description" content="{{ intro }}">
 {% else %}
-  <meta name="description" content="{{ site.description }}">
-  <meta property="og:description" content="{{ site.description }}">
-  <meta name="twitter:description" content="{{ site.description }}">
+  {% assign description = page.description | markdownify | strip_html %}
+  <meta name="description" content="{{ description }}">
+  <meta property="og:description" content="{{ description }}">
+  <meta name="twitter:description" content="{{ description }}">
 {% endif %}
 <meta name="twitter:card" content="summary_large_image">
 {% case page.layout %}

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -7,10 +7,10 @@
 <body>
   {% include navigation.html %}
   <main class="publication {{ page.class }}">
-    {% assign download_path = "/assets/studies/" | append: page.slug %}
+    {% assign image_path = "/assets/illustrations/" | append: page.slug %}
     <div class="section publication-cover"
          style="--bg-color: {{ page.background_color | default: 'dimgray' }};
-                --cover-img: url('{{ download_path }}.svg');">
+                --cover-img: url('{{ image_path }}.svg');">
       <div class="container">
         <div class="cover-img-desktop">
           <div class="titles">

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -27,11 +27,11 @@
       <div class="container clearfix">
         <div class="row topic-intro">
           <div class="col-12 col-lg-7 col-xl-6">
-            <img class="d-none d-md-block d-lg-none float-right col-6 pr-0 pb-3" loading="eager" src="/assets/topics/{{ page.slug }}.svg" alt="{{ page.title }}">
+            <img class="d-none d-md-block d-lg-none float-right col-6 pr-0 pb-3" loading="eager" src="/assets/illustrations/{{ page.slug }}.svg" alt="{{ page.title }}">
             {{ page.intro | markdownify }}
           </div>
           <div class="col-10 col-sm-8 d-md-none d-lg-block col-lg-5 col-xl-6 topic-icon">
-            <img class="px-xl-5" loading="eager" src="/assets/topics/{{ page.slug }}.svg" alt="{{ page.title }}">
+            <img class="px-xl-5" loading="eager" src="/assets/illustrations/{{ page.slug }}.svg" alt="{{ page.title }}">
           </div>
         </div>
         {%- if page.dashboard %}

--- a/utils/convert-illustration.sh
+++ b/utils/convert-illustration.sh
@@ -13,6 +13,8 @@ source utils/convert-svg.sh
 # Exit when any command fails
 set -e
 
+WIDTH=1200
+
 # Set up file names
 SRC_FILE_SVG=$1
 DST_FILE_SVG=$2
@@ -20,9 +22,9 @@ DST_FILE_SVG=$2
 # Create destination folders if necessary
 mkdir -p $(dirname $DST_FILE_SVG)
 
-# Convert SVG into PNG of width 1200px.
-echo -e `basename $SRC_FILE_SVG`": converting to PNG (${width}px)..."
-convert_svg_to_png "$SRC_FILE_SVG" "$DST_FILE_SVG" 1200
+# Convert SVG into PNG of desired $WIDTH.
+echo -e `basename $SRC_FILE_SVG`": converting to PNG ($WIDTH px)..."
+convert_svg_to_png "$SRC_FILE_SVG" "$DST_FILE_SVG" $WIDTH
 
 # If all previous conversions pass, copy the file checked by Make
 echo `basename $SRC_FILE_SVG`": copying to $DST_FILE_SVG..."

--- a/utils/convert-illustration.sh
+++ b/utils/convert-illustration.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Validate command line arguments
+if [ ! $# -eq 2 ]
+then
+    echo "Error: Incorrect number of parameters (exactly 2 parameters required)."
+    echo "Usage: "$0" <source/publication.svg> <destination/publication.svg>"
+    exit 1
+fi
+
+source utils/convert-svg.sh
+
+# Exit when any command fails
+set -e
+
+# Set up file names
+SRC_FILE_SVG=$1
+DST_FILE_SVG=$2
+
+# Create destination folders if necessary
+mkdir -p $(dirname $DST_FILE_SVG)
+
+# Convert SVG into PNG of width 1200px.
+echo -e `basename $SRC_FILE_SVG`": converting to PNG (${width}px)..."
+convert_svg_to_png "$SRC_FILE_SVG" "$DST_FILE_SVG" 1200
+
+# If all previous conversions pass, copy the file checked by Make
+echo `basename $SRC_FILE_SVG`": copying to $DST_FILE_SVG..."
+cp "$SRC_FILE_SVG" "$DST_FILE_SVG"
+
+echo `basename $SRC_FILE_SVG`": All done."

--- a/utils/convert-infographic.sh
+++ b/utils/convert-infographic.sh
@@ -8,29 +8,7 @@ then
     exit 1
 fi
 
-# Inkscape install instructions
-inkscape_install_instructions() {
-    echo "On Ubuntu, add ppa for the latest Inkscape and install it using the commands below."
-    echo "  sudo add-apt-repository ppa:inkscape.dev/stable"
-    echo "  sudo apt update"
-    echo "  sudo apt install inkscape"
-}
-
-# Check for Inkscape availability
-if ! (which inkscape >/dev/null 2>&1)
-then
-    echo "Error: Inkscape not installed."
-    inkscape_install_instructions
-    exit 2
-fi
-
-# Check Inkscape version
-if ! (inkscape --version 2>/dev/null | grep '^Inkscape 1\.' >/dev/null)
-then
-    echo "Error: You have an old version of Inkscape (below 1.0.0)."
-    inkscape_install_instructions
-    exit 3
-fi
+source utils/convert-svg.sh
 
 # Exit when any command fails
 set -e
@@ -56,24 +34,10 @@ inkscape \
         "$SRC_FILE_PDF" \
         >/dev/null 2>&1
 
-convert_svg_to_png() {
-    input_svg=$1
-    width=$2
-    inkscape \
-        --export-area-page \
-        --export-background=white \
-        --export-width=$width \
-        --export-background-opacity=255 \
-        --export-type=png \
-        --export-filename="${input_svg%.svg}_$width.png" \
-        "$input_svg" \
-        >/dev/null 2>&1
-}
-
 # Convert SVG into PNGs of various sizes
 for width in ${WIDTHS[@]}; do
     echo -e `basename $DST_FILE_SVG`": converting to PNG (${width}px)..."
-    convert_svg_to_png "$DST_FILE_SVG" $width
+    convert_svg_to_png "$DST_FILE_SVG" "$DST_FILE_SVG" $width
 done
 
 # If all previous conversions pass, copy the file checked by Make

--- a/utils/convert-svg.sh
+++ b/utils/convert-svg.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Inkscape install instructions
+inkscape_install_instructions() {
+    echo "On Ubuntu, add ppa for the latest Inkscape and install it using the commands below."
+    echo "  sudo add-apt-repository ppa:inkscape.dev/stable"
+    echo "  sudo apt update"
+    echo "  sudo apt install inkscape"
+}
+
+# Check for Inkscape availability
+if ! (which inkscape >/dev/null 2>&1)
+then
+    echo "Error: Inkscape not installed."
+    inkscape_install_instructions
+    exit 2
+fi
+
+# Check Inkscape version
+if ! (inkscape --version 2>/dev/null | grep '^Inkscape 1\.' >/dev/null)
+then
+    echo "Error: You have an old version of Inkscape (below 1.0.0)."
+    inkscape_install_instructions
+    exit 3
+fi
+
+convert_svg_to_png() {
+    input_svg=$1
+    output_svg=$2
+    width=$3
+    inkscape \
+        --export-area-page \
+        --export-background=white \
+        --export-width=$width \
+        --export-background-opacity=255 \
+        --export-type=png \
+        --export-filename="${output_svg%.svg}_$width.png" \
+        "$input_svg" \
+        >/dev/null 2>&1
+}


### PR DESCRIPTION
This PR restructures Makefiles to convert all svg illustrations for individual pages into pngs as well. These pngs are then used for og:image tags.

This PR also fixes og:description in two ways:
 - adds support for page.perex (used by explainers and publications),
 - trims Markdown from description (used by topics) by 'markdownify | trim_html' filters.