### PR TITLE
Explainer authors and types

### DIFF
--- a/_includes/author-internal.html
+++ b/_includes/author-internal.html
@@ -12,5 +12,4 @@
     {%- endif %}
   {%- endunless %}
   {%- unless forloop.last %}<span>, </span>{%- endunless %}
-{%- endfor %}
-{%- comment %}No new line at the end of this file (to avoid unintended space after author name).{%- endcomment %}
+{%- endfor -%}

--- a/_includes/author-internal.html
+++ b/_includes/author-internal.html
@@ -2,14 +2,19 @@
   {%- assign found=false %}
   {%- for group in site.data.organization-members %}
     {%- assign member = group.members | find: "id",id %}
-    {%- if member %}<span class="name"><a href="/o-nas#{{ member.id }}">{{ member.name_formal | default: member.name }}</a></span>{%- assign found=true %}{%- endif %}
+    {%- if member -%}
+      <span class="name"><a href="/o-nas#{{ member.id }}">{{ member.name_formal | default: member.name }}</a></span>
+      {%- assign found=true %}
+    {%- endif %}
   {%- endfor %}
   {%- unless found %}
-    {%- if include.check %}
+    {%- if include.check -%}
       <div class="build-error">Author {{ id }} is not present in organization members</div>
-    {%- else %}
+    {%- else -%}
       <span class="name">{{ id }}</span>
     {%- endif %}
   {%- endunless %}
-  {%- unless forloop.last %}<span>, </span>{%- endunless %}
+  {%- unless forloop.last -%}
+    <span>, </span>
+  {%- endunless %}
 {%- endfor -%}

--- a/_includes/author-internal.html
+++ b/_includes/author-internal.html
@@ -1,5 +1,4 @@
-{%- assign ids_list = include.ids | split: "," %}
-{%- for id in ids_list %}
+{%- for id in include.ids %}
   {%- assign found=false %}
   {%- for group in site.data.organization-members %}
     {%- assign member = group.members | find: "id",id %}
@@ -14,4 +13,4 @@
   {%- endunless %}
   {%- unless forloop.last %}<span>, </span>{%- endunless %}
 {%- endfor %}
-{%- comment %}# No new line at the end of this file (to avoid unintended space after author name).{%- endcomment %}
+{%- comment %}No new line at the end of this file (to avoid unintended space after author name).{%- endcomment %}

--- a/_includes/author-internal.html
+++ b/_includes/author-internal.html
@@ -1,0 +1,17 @@
+{%- assign ids_list = include.ids | split: "," %}
+{%- for id in ids_list %}
+  {%- assign found=false %}
+  {%- for group in site.data.organization-members %}
+    {%- assign member = group.members | find: "id",id %}
+    {%- if member %}<span class="name"><a href="/o-nas#{{ member.id }}">{{ member.name_formal | default: member.name }}</a></span>{%- assign found=true %}{%- endif %}
+  {%- endfor %}
+  {%- unless found %}
+    {%- if include.check %}
+      <div class="build-error">Author {{ id }} is not present in organization members</div>
+    {%- else %}
+      <span class="name">{{ id }}</span>
+    {%- endif %}
+  {%- endunless %}
+  {%- unless forloop.last %}<span>, </span>{%- endunless %}
+{%- endfor %}
+{%- comment %}# No new line at the end of this file (to avoid unintended space after author name).{%- endcomment %}

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -4,13 +4,12 @@
   {%- if author.show_internal_affiliation %}
     {%- assign affiliation = site.title %}
   {%- endif %}
-  {% include author-internal.html ids=author.id check=true %}
-{%- elsif author.ids %}
-  {%- assign ids = author.ids | join: "," %}
+  {%- assign ids = author.id | split: "," %}
   {% include author-internal.html ids=ids check=true %}
+{%- elsif author.ids %}
+  {% include author-internal.html ids=author.ids check=true %}
 {%- elsif author.names-or-ids %}
-  {%- assign ids = author.names-or-ids | join: "," %}
-  {% include author-internal.html ids=ids check=false %}
+  {% include author-internal.html ids=author.names-or-ids check=false %}
 {%- else %}
   {%- assign affiliation = author.affiliation %}
   {%- if author.link %}

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,25 +1,16 @@
 {%- assign author = include.author %}
-{%- if author.id or author.ids %}
+{%- assign affiliation = nil %}
+{%- if author.id %}
   {%- if author.show_internal_affiliation %}
     {%- assign affiliation = site.title %}
-  {%- else %}
-    {%- assign affiliation = nil %}
   {%- endif %}
-
-  {%- assign ids = author.ids | join: "," | default: author.id %}
-  {%- assign ids_list = ids | split: "," %}
-
-  {%- for id in ids_list %}
-    {%- assign found=false %}
-    {%- for group in site.data.organization-members %}
-      {%- assign member = group.members | find: "id",id %}
-      {%- if member %}<span class="name"><a href="/o-nas#{{ member.id }}">{{ member.name_formal | default: member.name }}</a></span>{%- assign found=true %}{%- endif %}
-    {%- endfor %}
-    {%- unless forloop.last %}<span>, </span>{%- endunless %}
-    {%- unless found %}
-    <div class="build-error">Author {{ id }} is not present in organization members</div>
-    {%- endunless %}
-  {%- endfor %}
+  {% include author-internal.html ids=author.id check=true %}
+{%- elsif author.ids %}
+  {%- assign ids = author.ids | join: "," %}
+  {% include author-internal.html ids=ids check=true %}
+{%- elsif author.names-or-ids %}
+  {%- assign ids = author.names-or-ids | join: "," %}
+  {% include author-internal.html ids=ids check=false %}
 {%- else %}
   {%- assign affiliation = author.affiliation %}
   {%- if author.link %}
@@ -28,4 +19,4 @@
     <span class="name">{{ author.name }}</span>
   {%- endif %}
 {%- endif %}
-{%- if affiliation %}, <span class="affiliation">{{ affiliation }}</span>{%- endif %}
+{%- if affiliation %}<span class="affiliation">, {{ affiliation }}</span>{%- endif %}

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -18,4 +18,6 @@
     <span class="name">{{ author.name }}</span>
   {%- endif %}
 {%- endif %}
-{%- if affiliation %}<span class="affiliation">, {{ affiliation }}</span>{%- endif %}
+{%- if affiliation -%}
+  <span class="affiliation">, {{ affiliation }}</span>
+{%- endif -%}

--- a/_includes/preview-block-small.html
+++ b/_includes/preview-block-small.html
@@ -9,11 +9,9 @@
         </div>
     {%- when 'explainer' %}
         <div style="background-image: url('/assets/covers/{{ item.slug }}_600.jpg')" class="specific-card"></div>
-        {%- if item.type %}
-            <div class="card-img-overlay small-card-img-overlay">
-                <h5>{{ item.type }}</h5>
-            </div>
-        {%- endif %}
+        <div class="card-img-overlay small-card-img-overlay">
+            <h5>{{ item.type | default: site.data.lang.text.explainer.explainer }}</h5>
+        </div>
     {%- when 'study' %}
         <div style="background-image: url('/assets/studies/{{ item.slug }}.jpg')" class="specific-card"></div>
         <div class="card-img-overlay small-card-img-overlay">

--- a/_includes/preview-block-small.html
+++ b/_includes/preview-block-small.html
@@ -9,9 +9,11 @@
         </div>
     {%- when 'explainer' %}
         <div style="background-image: url('/assets/covers/{{ item.slug }}_600.jpg')" class="specific-card"></div>
-        <div class="card-img-overlay small-card-img-overlay">
-            <h5>{{ site.data.lang.text.explainer.explainer }}</h5>
-        </div>
+        {%- if item.type %}
+            <div class="card-img-overlay small-card-img-overlay">
+                <h5>{{ item.type }}</h5>
+            </div>
+        {%- endif %}
     {%- when 'study' %}
         <div style="background-image: url('/assets/studies/{{ item.slug }}.jpg')" class="specific-card"></div>
         <div class="card-img-overlay small-card-img-overlay">

--- a/_includes/preview-block-without-link.html
+++ b/_includes/preview-block-without-link.html
@@ -15,11 +15,13 @@
             <h6 class="card-subtitle">{{ site.data.lang.text.dataset.dataset }}</h6>
         </div>
     {% when 'explainer' %}
-        <div style="background-image: url('/assets/covers/{{ item.slug }}_600.jpg')" title="{{ site.data.lang.text.explainer.explainer }}: {{ item.title }}" class="preview-card-image img-fluid card-img">
+        <div style="background-image: url('/assets/covers/{{ item.slug }}_600.jpg')" title="{{ item.title }}" class="preview-card-image img-fluid card-img">
         </div>
         <div class="card-img-overlay card-title-overlay">
             <h5 class="card-title">{{ title }}</h5>
-            <h6 class="card-subtitle">{{ site.data.lang.text.explainer.explainer }}</h6>
+            {%- if item.type %}
+                <h6 class="card-subtitle">{{ item.type }}</h6>
+            {%- endif %}
         </div>
     {% when 'study' %}
         <div style="background-image: url('/assets/studies/{{ item.slug }}.jpg')" title="{{ site.data.lang.text.study.study }}: {{ item.title }}" class="preview-card-image img-fluid card-img">

--- a/_layouts/explainer.html
+++ b/_layouts/explainer.html
@@ -64,8 +64,10 @@
                   <span class="series-title">{{ page.title }}</span>
               </h1>
               <div class="explainer-metadata">
-                <span class="date">{{ page.published | date: "%-d. %-m. %Y" }}</span>
-                {% include tags.html tags=page.tags slug=page.slug link="true" %}
+                <div class="date-tags">
+                  <div class="date">{{ page.published | date: "%-d. %-m. %Y" }}</div>
+                  {% include tags.html tags=page.tags slug=page.slug link="true" %}
+                </div>
                 {%- if page.author %}
                   <span class="authors author"><a href="/{{ site.slugs.about }}#members">{{ page.author }}</a></span>
                 {%- else if page.authors %}

--- a/_layouts/explainer.html
+++ b/_layouts/explainer.html
@@ -53,8 +53,8 @@
                       {%- break %}
                     {%- endif %}
                   {%- endfor %}
-                {%- else %}
-                  {{ site.data.lang.text.explainer.explainer }}
+                {%- else if page.type %}
+                  {{ page.type }}
                 {%- endif %}
               </div>
               <h1>

--- a/_layouts/explainer.html
+++ b/_layouts/explainer.html
@@ -64,10 +64,13 @@
                   <span class="series-title">{{ page.title }}</span>
               </h1>
               <div class="explainer-metadata">
-                {% include tags.html tags=page.tags slug=page.slug link="true" %}
-                <span class="author"><a href="/{{ site.slugs.about }}#members">{{ page.author }}</a></span>
                 <span class="date">{{ page.published | date: "%-d. %-m. %Y" }}</span>
-              {% assign download_path = "/assets/studies/" | append: page.slug %}
+                {% include tags.html tags=page.tags slug=page.slug link="true" %}
+                {%- if page.author %}
+                  <span class="authors author"><a href="/{{ site.slugs.about }}#members">{{ page.author }}</a></span>
+                {%- else if page.authors %}
+                  {% include authors.html authors=page.authors %}
+                {%- endif %}
               </div>
             </div>
           </div>

--- a/assets/_scss/explainer.scss
+++ b/assets/_scss/explainer.scss
@@ -75,21 +75,18 @@
     padding-top: 1rem;
     padding-bottom: 1rem;
     font-size: 1.1rem;
-    text-align: right;
+    display: flex;
+
+    .tags {
+        flex-grow: 1;
+    }
 
     .author {
         font-weight: bold;
     }
 
-    .date::before {
-        content: "•";
-        font-weight: bold;
-        padding-left: .5rem;
-        padding-right: .5rem;
-    }
-
-    .tags {
-        float: left;
+    .date {
+        padding-right: 1.5rem;
     }
 }
 
@@ -137,7 +134,7 @@ h1 {
             // min-height: calc(1.2em * 3);  // minimum three lines
             vertical-align: baseline;
         }
-        .author a {
+        .authors a {
             color: white;
         }
         .tags {

--- a/assets/_scss/explainer.scss
+++ b/assets/_scss/explainer.scss
@@ -75,10 +75,9 @@
     padding-top: 1rem;
     padding-bottom: 1rem;
     font-size: 1.1rem;
-    display: flex;
 
-    .tags {
-        flex-grow: 1;
+    .date-tags {
+        margin-bottom: 0.5rem;
     }
 
     .author {
@@ -86,7 +85,8 @@
     }
 
     .date {
-        padding-right: 1.5rem;
+        margin-bottom: 0.5rem;
+        padding-left: 0.5rem;
     }
 }
 
@@ -126,7 +126,7 @@ h1 {
         background-size: cover;
         background-blend-mode: multiply;
         background-color: #a0a5b8 !important;
-        padding-top: 12%;
+        padding-top: 11%;
         color: white;
         text-shadow: 0px 0px 0.1rem black;
         h1 {
@@ -147,7 +147,19 @@ h1 {
     }
 
     .explainer-metadata {
-        padding-top: 5%;
+        padding-top: 4%;
+        display: flex;
+        align-items: center;
+
+        .date-tags {
+            flex-grow: 1;
+            display: flex;
+        }
+
+        .date::after {
+            content: "•";
+            padding-inline: .5rem;
+        }
     }
 }
 


### PR DESCRIPTION
This PR makes two changes:
- removes "explainer" labels (except for small preview boxes in search results) and allows custom types where we want to stress specialty of some long / complex text;
- improves authorship section for explainers. It is backwards compatible to still allow the previous free-form unstructered text.

In the process, this PR refactors authors.html a bit - allowing more flexibility (that is needed by a wider range of applications in existing explainers in web-cz). After this PR, each line in authors correspond to one author / group of authors in a similar role. It can be specified by one of the following:
 - `id`: [string id of an internal member]
 - `name`: [string expressing the name of an external author]
 - `ids`: [array of string ids of internal authors]
 - `names-or-ids`: [array of strings that are either id of an internal author or name of an external author]

More remarks:
- `id` and `ids` enforce existence of such an internal author(s), `names-or-ids` not. 
- Only `name` allows specifying external `affiliation` and `link`. For internal authors, internal links get always auto-generated; internal affiliation gets shown iff `show_internal_affiliation` is `true`.
- Major authors can get specified together on one line (e.g. using `ids`) or on one line each (e.g., using `id`). Each of the options look better in different cases and thus co-exist deliberately.