### PR TITLE
Allow skipping ligtbox for figures

### DIFF
--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -2,6 +2,17 @@
   {%- if include.caption-above %}
     <div class="caption caption-above">{{ include.caption-above | markdownify }}</div>
   {%- endif %}
+  {%- capture picture %}
+  <picture>
+    {%- if include.name-mobile %}
+    <source media="(max-width: 575px)" srcset="/assets-local/figures/{{ page.slug }}/{{ include.name-mobile }}" />
+    {%- endif %}
+    <img src="/assets-local/figures/{{ page.slug }}/{{ include.name }}" alt="{{ include.alt }}" class="{{ include.image-class }}">
+  </picture>
+  {%- endcapture %}
+  {%- if include.no-lightbox %}
+    {{ picture }}
+  {%- else %}
   <a class="lightbox-desktop-only" href="/assets-local/figures/{{ page.slug }}/{{ include.name }}" data-lightbox
     {%- assign suffix = include.name | split:'.' | last %}
     {%- if suffix == "svg" %}
@@ -10,13 +21,9 @@
     {%- if include.caption or include.source-text %}
     data-caption="..."
     {%- endif %}>
-    <picture>
-      {%- if include.name-mobile %}
-      <source media="(max-width: 575px)" srcset="/assets-local/figures/{{ page.slug }}/{{ include.name-mobile }}" />
-      {%- endif %}
-      <img src="/assets-local/figures/{{ page.slug }}/{{ include.name }}" alt="{{ include.alt }}" class="{{ include.image-class }}">
-    </picture>
+    {{ picture }}
   </a>
+  {%- endif %}
   {%- if include.caption or include.source-text %}
   <div class="fancybox-custom-caption">
     {%- if include.caption %}


### PR DESCRIPTION
This PR adds an argument to figure.html to avoid lightbox.

This is useful for smaller figures / illustrations embedded in grid layout, etc.