### PR TITLE
Support declaring last update for an explainer

### DIFF
--- a/_layouts/explainer.html
+++ b/_layouts/explainer.html
@@ -68,7 +68,10 @@
                   <div class="date">
                     {{ page.published | date: "%-d. %-m. %Y" }}
                     {%- if page.updated %}
-                      <span class="updated">({{ site.data.lang.text.explainer.updated }} {{ page.updated | date: "%-d. %-m. %Y" }})</span>
+                      <span class="updated">
+                        ({{ site.data.lang.text.explainer.updated }}
+                        {{ page.updated | date: "%-d. %-m. %Y" }})
+                      </span>
                     {%- endif %}
                   </div>
                   {% include tags.html tags=page.tags slug=page.slug link="true" %}

--- a/_layouts/explainer.html
+++ b/_layouts/explainer.html
@@ -65,7 +65,12 @@
               </h1>
               <div class="explainer-metadata">
                 <div class="date-tags">
-                  <div class="date">{{ page.published | date: "%-d. %-m. %Y" }}</div>
+                  <div class="date">
+                    {{ page.published | date: "%-d. %-m. %Y" }}
+                    {%- if page.updated %}
+                      <span class="updated">({{ site.data.lang.text.explainer.updated }} {{ page.updated | date: "%-d. %-m. %Y" }})</span>
+                    {%- endif %}
+                  </div>
                   {% include tags.html tags=page.tags slug=page.slug link="true" %}
                 </div>
                 {%- if page.author %}

--- a/assets/_scss/explainer.scss
+++ b/assets/_scss/explainer.scss
@@ -87,6 +87,10 @@
     .date {
         margin-bottom: 0.5rem;
         padding-left: 0.5rem;
+        .updated {
+            font-size: 0.9rem;
+            opacity: 0.8;
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds simple support for last-update date for explainers.

This is useful for better transparency around our texts, especially when making some larger changes.