### PR TITLE
Fix object reference in og:image link construction

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -30,7 +30,7 @@
 {% when 'study' %}
   {% assign social_image = "/assets/studies/" | append: page.slug | append: ".jpg" %}
 {% when 'survey' %}
-  {%- if item.use-preview-image %}
+  {%- if page.use-preview-image %}
     {% assign social_image = "/assets/studies/" | append: page.slug | append: ".jpg" %}
   {%- endif %}
 {% when 'explainer' %}


### PR DESCRIPTION
Use the `page` object instead of the undefined `item`.