### PR TITLE
Use preview image for og:image

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,7 +23,7 @@
 <meta property="og:description" content="{{ description }}">
 <meta name="twitter:description" content="{{ description }}">
 <meta name="twitter:card" content="summary_large_image">
-{% assign social_image = "/assets-local/img/preview.png" %}
+{% assign social_image = page.preview_image | default: "/assets-local/img/preview.png" %}
 {% case page.layout %}
 {% when 'infographic' %}
   {% assign social_image = "/assets/generated/" | append: page.slug | append: "_1200.png" %}

--- a/_includes/preview-block-small.html
+++ b/_includes/preview-block-small.html
@@ -40,14 +40,14 @@
             <h5>{{ site.data.lang.text.episode.episode }} <i class="fas fa-external-link-alt"></i></h5>
         </div>
     {%- else %}
-        {%- if item.search_type %}
-            {%- if item.search_image %}
-                <div style="--background: url('{{ item.search_image }}')" class="specific-card small-card-bg"></div>
+        {%- if item.preview_type %}
+            {%- if item.preview_image %}
+                <div style="--background: url('{{ item.preview_image }}')" class="specific-card small-card-bg"></div>
             {%- else %}
                 <div class='branded-card'></div>
             {%- endif %}
             <div class='card-img-overlay small-card-img-overlay'>
-                <h5>{{ page.search_type }}</h5>
+                <h5>{{ page.preview_type }}</h5>
             </div>
         {%- else %}
             <div class="card-img-overlay small-card-img-overlay">

--- a/_includes/preview-block-without-link.html
+++ b/_includes/preview-block-without-link.html
@@ -64,15 +64,15 @@
             <h6 class="card-subtitle">{{ site.data.lang.text.episode.episode }} <i class="fas fa-external-link-alt"></i></h6>
         </div>
     {% else %}
-        {%- if item.search_type %}
-            {%- if item.search_image %}
-                <div style="--background: url('{{ item.search_image }}')" title="{{ page.search_type }}: {{ item.title }}" class="preview-card-image img-fluid card-img"></div>
+        {%- if item.preview_type %}
+            {%- if item.preview_image %}
+                <div style="--background: url('{{ item.preview_image }}')" title="{{ page.preview_type }}: {{ item.title }}" class="preview-card-image img-fluid card-img"></div>
             {%- else %}
                 <div class='branded-card preview-card-image img-fluid card-img'></div>
             {%- endif %}
             <div class="card-img-overlay card-title-overlay">
                 <h5 class="card-title">{{ title }}</h5>
-                <h6 class="card-subtitle">{{ item.search_type }}</h6>
+                <h6 class="card-subtitle">{{ item.preview_type }}</h6>
             </div>
         {%- else %}
             <div class="build-error">Unknown layout ‘{{ item.layout }}’</div>

--- a/search.json
+++ b/search.json
@@ -2,7 +2,7 @@
 layout: null
 ---
 [
-  {%- assign pages = site.pages | where_exp: "page", "page.search_type" %}
+  {%- assign pages = site.pages | where_exp: "page", "page.include_in_search" %}
   {%- assign objects = site.infographics | concat: site.studies | concat: site.explainers | concat: site.episodes | sort: "published" | reverse %}
   {%- assign all = pages | concat: objects %}
   {%- for page in all %}


### PR DESCRIPTION
This PR makes use of `search_image` for social media.

To this end:
- `search_image` and `search_type` are renamed to `preview_image` and `preview_type` as they are anyway also used for in-site preview blocks;
- existence in search index is decoupled from `preview_type` a new boolean property `include_in_search` is introduced for the pages collection instead.