### PR TITLE
Fix explainer cover (with updated date) on mobile

### DIFF
--- a/assets/_scss/explainer.scss
+++ b/assets/_scss/explainer.scss
@@ -93,19 +93,20 @@
 
     .date-tags {
         display: flex;
+        flex-wrap: wrap;
+    }
+
+    .date, .tags {
+        margin-top: 1rem;
     }
 
     .date {
-        flex-shrink: 0;
         .updated {
             font-size: 0.9rem;
             opacity: 0.8;
         }
 
-        &::after {
-            content: "•";
-            padding-inline: .5rem;
-        }
+        padding-right: 2rem;
     }
 }
 


### PR DESCRIPTION
This PR fixes layout for updated publication dates on mobile. It makes tags wrap on another line if all the content does not fit on one line. To this end, it replaces the middot separator with more spacing (as it is not clear to CSS if it splits to multiple lines).