### PR TITLE
Allow no link for internal authors

### DIFF
--- a/_includes/author-internal.html
+++ b/_includes/author-internal.html
@@ -3,7 +3,15 @@
   {%- for group in site.data.organization-members %}
     {%- assign member = group.members | find: "id",id %}
     {%- if member -%}
-      <span class="name"><a href="/o-nas#{{ member.id }}">{{ member.name_formal | default: member.name }}</a></span>
+      <span class="name">
+        {%- unless member.no_link %}
+          <a href="/o-nas#{{ member.id }}">
+            {{ member.name_formal | default: member.name }}
+          </a>
+        {%- else %}
+          {{ member.name_formal | default: member.name }}
+        {%- endunless %}
+      </span>
       {%- assign found=true %}
     {%- endif %}
   {%- endfor %}


### PR DESCRIPTION
This PR supports structured authorship for explainers without linking to an internal "Team" page. This is useful for the SK/EN sites.