### PR TITLE
Ignore Mac .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@
 # Temporary files
 *~
 
+# Mac Finder files
+*.DS_Store
+
 # IDE files
 .idea
 .vscode


### PR DESCRIPTION
This PR makes ignore .DS_Store files created by Mac Finder when browsing through the files of the repo.