### PR TITLE
Highlight text elements with titles

### DIFF
--- a/assets/_scss/core_design.scss
+++ b/assets/_scss/core_design.scss
@@ -155,6 +155,11 @@ pre {
     }
 }
 
+span[title] {
+    text-decoration: underline dotted $c-secondary;
+    cursor: pointer;
+}
+
 /* Popovers */
 
 .popover-header {


### PR DESCRIPTION
This makes it apparent that elements with titles and tooltips can be hovered over to reveal an explanation or other kind of information.