### PR TITLE
Hide duplicate minor roles

### DIFF
--- a/_includes/authors.html
+++ b/_includes/authors.html
@@ -11,9 +11,12 @@
   {%- assign minors = include.authors | where_exp: "author","author.minor-role != nil" %}
   {%- if minors.size > 0 %}
     <dl class="authors-minor">
+    {% assign previous_role = "" %}
       {%- for author in minors %}
-        <dt>{{ author.minor-role }}:</dt>
+        <dt{% if author.minor-role == previous_role %} class="invisible"{% endif %}>
+            {{- author.minor-role }}:</dt>
         <dd>{% include author.html author=author %}</dd>
+        {% assign previous_role = author.minor-role %}
       {%- endfor %}
     </dl>
   {%- endif %}


### PR DESCRIPTION
Hide minor role label if it is the same as for the previous person. For example, if there are two consulting roles, hide the label for the second one.

[Preview](https://cz-fakta-o-klimatu--preview-minor-role-dupl-4xuiuoh0.web.app/explainery/zdravi-pudy-degradace)