### PR TITLE
Fix deployment step

### DIFF
--- a/.travis.global.yml
+++ b/.travis.global.yml
@@ -48,12 +48,14 @@ before_deploy:
 deploy:
   # Firebase production deployment
   - provider: script # uses FIREBASE_TOKEN
+    edge: true
     on:
       branch: master
     skip_cleanup: true
     script: make deploy-production
   # Firebase preview deployment
   - provider: script # uses FIREBASE_TOKEN
+    edge: true
     on:
       all_branches: true
       condition: $TRAVIS_BRANCH = preview-*

--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,10 @@ check: build
 lighthouse: build
 	lhci autorun
 
-deploy-preview: build
+deploy-preview:
 	./firebase hosting:channel:deploy $(BRANCH) --only preview
 
-deploy-production: build
+deploy-production:
 	./firebase deploy --only hosting:production
 
 # === Targets for generating files  ===


### PR DESCRIPTION
- Opt-in to the v2 of Travis deployment scripts for better Ruby
compatibility. v1 scripts use Ruby 2 which seems to be in conflict with
our Gem dependencies.
- Do not trigger build for the second or third time during deployment – it is a waste of time and does not belong to this phase.