### PR TITLE
Bump webrick dependency due to a CVE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,5 @@ gem 'nokogiri', '~> 1.13'
 # Local fix applied (URI escaping needed). Pull request submitted.
 # gem 'jekyll-target-blank'
 
-# Temporary workaround enabling build with Ruby 3+ (e.g. Fedora 34)
-gem "webrick", "~> 1.7"
+# Fix for CVE-2024-47220, https://nvd.nist.gov/vuln/detail/CVE-2024-47220
+gem 'webrick', '>= 1.8.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,17 +2,17 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.1)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     afm (0.2.2)
-    async (2.12.0)
-      console (~> 1.25, >= 1.25.2)
+    async (2.17.0)
+      console (~> 1.26)
       fiber-annotation
-      io-event (~> 1.6)
+      io-event (~> 1.6, >= 1.6.5)
     bigdecimal (3.1.8)
     colorator (1.1.0)
-    concurrent-ruby (1.3.3)
-    console (1.25.2)
+    concurrent-ruby (1.3.4)
+    console (1.27.0)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -31,12 +31,12 @@ GEM
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
-    fiber-storage (0.1.1)
+    fiber-storage (1.0.0)
     forwardable-extended (2.6.0)
-    google-protobuf (4.27.1)
+    google-protobuf (4.28.2)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.27.1-x86_64-linux)
+    google-protobuf (4.28.2-x86_64-linux)
       bigdecimal
       rake (>= 13)
     hashery (2.1.2)
@@ -51,10 +51,10 @@ GEM
       zeitwerk (~> 2.5)
     htmlbeautifier (1.4.3)
     http_parser.rb (0.8.0)
-    i18n (1.14.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    io-event (1.6.4)
-    jekyll (4.3.3)
+    io-event (1.6.5)
+    jekyll (4.3.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -96,10 +96,10 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     mini_portile2 (2.8.7)
-    nokogiri (1.16.6)
+    nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-linux)
+    nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -109,34 +109,32 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    public_suffix (5.0.5)
-    racc (1.8.0)
+    public_suffix (6.0.1)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.0)
-      strscan
-    rouge (4.2.1)
+    rexml (3.3.7)
+    rouge (4.4.0)
     ruby-rc4 (0.1.5)
     safe_yaml (1.0.5)
-    sass-embedded (1.77.5)
-      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.79.3)
+      google-protobuf (~> 4.27)
       rake (>= 13)
-    sass-embedded (1.77.5-x86_64-linux-gnu)
-      google-protobuf (>= 3.25, < 5.0)
-    strscan (3.1.0)
+    sass-embedded (1.79.3-x86_64-linux-gnu)
+      google-protobuf (~> 4.27)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     ttfunk (1.8.0)
       bigdecimal (~> 3.1)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
-    unicode-display_width (2.5.0)
-    webrick (1.8.1)
+    unicode-display_width (2.6.0)
+    webrick (1.8.2)
     yell (2.2.2)
-    zeitwerk (2.6.15)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   ruby
@@ -154,7 +152,7 @@ DEPENDENCIES
   jekyll-sitemap
   kramdown-math-katex
   nokogiri (~> 1.13)
-  webrick (~> 1.7)
+  webrick (>= 1.8.2)
 
 BUNDLED WITH
    2.2.15


### PR DESCRIPTION
Bump webrick dependency in order to include a fix for [CVE-2024-47220](https://nvd.nist.gov/vuln/detail/CVE-2024-47220).